### PR TITLE
C++11 HURRAY!

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ APPCLIENT=$(APPNAME)
 APPSERVER=$(APPNAME)_server
 
 #CXXFLAGS= -ggdb3
-CXXFLAGS= -O3 -fomit-frame-pointer -ffast-math
+CXXFLAGS= -std=c++11 -O3 -fomit-frame-pointer -ffast-math
 override CXXFLAGS+= -Wall -fsigned-char -fno-exceptions -fno-rtti
 
 PLATFORM= $(shell uname -s)

--- a/src/redeclipse.cbp
+++ b/src/redeclipse.cbp
@@ -21,9 +21,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
+					<Add option="-ffast-math" />
 					<Add option="-m32" />
 					<Add option="-mwindows" />
 					<Add option="-fsigned-char" />
@@ -112,6 +113,7 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
 					<Add option="-pg" />
 					<Add option="-m32" />
 					<Add option="-mwindows" />
@@ -124,6 +126,7 @@
 					<Add directory="include" />
 				</Compiler>
 				<Linker>
+					<Add option="-pg" />
 					<Add option="-pg -lgmon" />
 					<Add option="-m32" />
 					<Add option="-mwindows" />
@@ -156,9 +159,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
+					<Add option="-ffast-math" />
 					<Add option="-m32" />
 					<Add option="-mwindows" />
 					<Add option="-fsigned-char" />
@@ -200,6 +204,7 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
 					<Add option="-g" />
 					<Add option="-m32" />
 					<Add option="-mwindows" />
@@ -240,9 +245,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
+					<Add option="-ffast-math" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
 					<Add option="-fsigned-char" />
@@ -288,6 +294,7 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
 					<Add option="-g" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
@@ -331,6 +338,7 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
 					<Add option="-pg" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
@@ -343,6 +351,7 @@
 					<Add directory="include" />
 				</Compiler>
 				<Linker>
+					<Add option="-pg" />
 					<Add option="-pg -lgmon" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
@@ -375,9 +384,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++0x" />
+					<Add option="-ffast-math" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
 					<Add option="-fsigned-char" />
@@ -419,6 +429,7 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wall" />
+					<Add option="-std=c++0x" />
 					<Add option="-g" />
 					<Add option="-m64" />
 					<Add option="-mwindows" />
@@ -459,9 +470,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
+					<Add option="-ffast-math" />
 					<Add option="-fsigned-char" />
 					<Add option="-fno-exceptions" />
 					<Add option="-fno-rtti" />
@@ -501,9 +513,10 @@
 				<Option projectLibDirsRelation="1" />
 				<Compiler>
 					<Add option="-fomit-frame-pointer" />
-					<Add option="-ffast-math" />
 					<Add option="-O3" />
 					<Add option="-Wall" />
+					<Add option="-std=c++11" />
+					<Add option="-ffast-math" />
 					<Add option="-fsigned-char" />
 					<Add option="-fno-exceptions" />
 					<Add option="-mwindows" />


### PR DESCRIPTION
It been good 4 years for C++ and compiler vendors to produce production quality c++11 compilers. G++ 4.8.1, Clang 3.5 and other offset full or almost full support for c++11 and some even c++14. Two years ago, when I first proposed moving to c++11, it could've been to hasty but now is the right time.