### PR TITLE
a search filter for serverdesc and players

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -137,10 +137,6 @@ servermenu = [
                 ]
             ]
         ]
-        guilist [
-            guifield searchtagval 20 [searchtag = $searchtagval; search = 1] -1 0 "" 0 "^fd <enter search terms>"
-            guicheckbox "only show servers with matching players or descriptions" search 
-        ]
         guistrut 0.25
         if (> (getversion 3) (getversion 1)) [
             guilist [ guibutton "^fzoynew version released! ^fwget it now from: ^fcwww.redeclipse.net" "" ]
@@ -298,6 +294,13 @@ servermenu = [
     guistrut 0.5
         guilist [
             guifont "little" [
+                guicheckbox "filter:" search 
+                if (=s $guirollovername "filter:") [
+                    guitooltip "^faUsing a search filter will only show matching servers. Searches for server descriptions, player names and user handles."
+                ]
+                guistrut 0.5
+                guifield searchtagval 18 [searchtag = $searchtagval; search = 1] -1 0 "" 0 "^fd <enter search terms>" 1
+                guispring 1
                 guitext "sort: "
                 loop i (listlen $serversort) [
                     sinfostype = (at $serversort $i)

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -35,6 +35,8 @@ servermenuinit = [
     sinfouitime = (getmillis 1)
     shownservergui = 0
     updateservergui = 0
+    search = 0
+    searchtag = "" 
 ]
 servermenuiter = [
     if (! $shownservergui) [
@@ -91,7 +93,19 @@ servermenu = [
         sinfoofft = (? (>= $sinfolast 0) (div (max (- (getmillis 1) (- $sinfolast (div $sinfoping 2))) 0) 1000) 0)
         sinfoactive = (? (< $sinfoping $serverwaiting) 1 0)
         sinfonumsrv = (? $i (+ $sinfonumsrv $sinfoactive) $sinfoactive)
-    ] [1] [
+        players = " "
+        if (> $sinfonump 0 ) [
+            loop j $sinfonump [
+                // if $j [ append players " - " ]
+                phandle = (getserver $i 3 $j)
+                if (strlen $phandle) [ 
+                    append players (format "%1 (%2)" (getserver $i 2 $j) $phandle)
+                ] [
+                    append players (format "%1" (getserver $i 2 $j))
+                ]
+            ]
+        ]
+    ] [(|| (= $search 0)  (> (strcasestr (concat $sinfodesc (stripcolors $players)) $searchtag) -1))] [ 
         if $updateservergui [
             guibutton "^fwThere are no servers to display, maybe ^fgupdate ^fwthe list?" updatefrommaster [] "info"
         ] [
@@ -122,6 +136,10 @@ servermenu = [
                     guistrut 1
                 ]
             ]
+        ]
+        guilist [
+            guifield searchtagval 20 [searchtag = $searchtagval; search = 1] -1 0 "" 0 "^fd <enter search terms>"
+            guicheckbox "only show servers with matching players or descriptions" search 
         ]
         guistrut 0.25
         if (> (getversion 3) (getversion 1)) [


### PR DESCRIPTION
A search field and checkbox to only show servers with matching player names, player handles or server descriptions. A proper implementation is certainly preferable, maybe via the sort functionality, but this hack seems to work well enough to be useful. So, I'm not sure if it is worth pushing.
Related topic: http://redeclipse.net/forum/viewtopic.php?f=5&t=490&p=4216