### PR TITLE
better color info; spacing after "value" text

### DIFF
--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -69,14 +69,6 @@ newgui vars [
                         guitext (format "^famax: ^fw%1" (getvarmax $scurvar))
                         guispring 1
                         guitext (format "^fadefault: ^fw%1" (getvardef $scurvar 1))
-                        if (= 0xffffff (getvarmax $scurvar)) [
-                            guispring 1
-                            guitext "preview: " "" $$scurvar 
-                            guilist [
-                                guibackground 0xcccccc
-                                guitext (hexcolour $$scurvar) "" $$scurvar 
-                            ]
-                        ] 
                     ] 1 [
                         guitext "^fafloat"
                         guispring 1
@@ -108,10 +100,22 @@ newgui vars [
                 guistrut 0.25
                 guilist [
                     guitext "value"
-                    guispring 1
+                    guistrut 1
                     [@[scurvar]_varval] = $$scurvar
                     guifield [@[scurvar]_varval] -58 [@scurvar $[@@[scurvar]_varval]] -1 0 "" (? (|| (= $scurvartype 2) (= $scurvartype 4)) 8 1)
                 ]
+                if (= $scurvartype 0) [
+                    if (= 0xffffff (getvarmax $scurvar)) [
+                        guistrut 0.25
+                        guilist [
+                            guitext (format "^fahex value: ^fw%1" (hexcolour $$scurvar))
+                            guispring 1
+                            guitext "^fa preview:"
+                            guistrut 1
+                            guiimage "textures/guiskin.png" [] 1.5 0 "" [] $$scurvar
+                        ]
+                    ] 
+                ] 
                 scurusage = (getvarusage $scurvar)
                 if (strlen $scurusage) [
                     guistrut 0.25


### PR DESCRIPTION
I'm sorry if I made a mess with https://github.com/red-eclipse/base/pull/28.
I do hope this version is much better and actually useful.
Also, I noticed the spring between the "value" text and input field creates no spacing (as this is usually the longest line), so I replaced it with a guistrut.