### PR TITLE
enhance search filter for server menu

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -23,7 +23,6 @@ sinfomodify = [
     ]
     serversort $sinfotlist
 ]
-
 servermenuinit = [
     sinfoindex = 0
     sinfowait = 0
@@ -35,8 +34,8 @@ servermenuinit = [
     sinfouitime = (getmillis 1)
     shownservergui = 0
     updateservergui = 0
-    search = 0
-    searchtag = "" 
+    searchfilter = 0
+    searchstr = "" 
 ]
 servermenuiter = [
     if (! $shownservergui) [
@@ -93,19 +92,14 @@ servermenu = [
         sinfoofft = (? (>= $sinfolast 0) (div (max (- (getmillis 1) (- $sinfolast (div $sinfoping 2))) 0) 1000) 0)
         sinfoactive = (? (< $sinfoping $serverwaiting) 1 0)
         sinfonumsrv = (? $i (+ $sinfonumsrv $sinfoactive) $sinfoactive)
-        players = " "
+        searchbuffer = (concat $sinfodesc $sinfonpid $sinfomapn (gamename $sinfomode $sinfomuts 0))
         if (> $sinfonump 0 ) [
             loop j $sinfonump [
-                // if $j [ append players " - " ]
-                phandle = (getserver $i 3 $j)
-                if (strlen $phandle) [ 
-                    append players (format "%1 (%2)" (getserver $i 2 $j) $phandle)
-                ] [
-                    append players (format "%1" (getserver $i 2 $j))
-                ]
+                append searchbuffer (getserver $i 2 $j) // the player name
+                append searchbuffer (getserver $i 3 $j) // and handle
             ]
         ]
-    ] [(|| (= $search 0)  (> (strcasestr (concat $sinfodesc (stripcolors $players)) $searchtag) -1))] [ 
+    ] [(|| (= $searchfilter 0)  (> (strcasestr $searchbuffer $searchstr) -1))] [ 
         if $updateservergui [
             guibutton "^fwThere are no servers to display, maybe ^fgupdate ^fwthe list?" updatefrommaster [] "info"
         ] [
@@ -302,12 +296,12 @@ servermenu = [
         ]
         guistrut 0.5
         guilist [
-            guicenterz [ guicheckbox "filter:" search ]
+            guicenterz [ guicheckbox "filter:" searchfilter ]
             if (=s $guirollovername "filter:") [
-                guitooltip "^faUsing a search filter will only show matching servers. Searches for server descriptions, player names and user handles."
+                guitooltip "^faThis will only list matching servers. Allows to search for names and handles of connected players, currently played maps, modes and mutators, or server descriptions, ips and ports." 
             ]
             guistrut 0.5
-            guifield searchtagval 18 [searchtag = $searchtagval; search = 1] -1 0 "" 0 "^fd <enter search terms>" 1
+            guifield searchstrval 18 [searchstr = $searchstrval; searchfilter = 1] -1 0 "" 0 "^fd <enter search terms>" 1
             guispring 1
             guicenterz [
                 guitext "sort:"

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -298,7 +298,7 @@ servermenu = [
         guilist [
             guicenterz [ guicheckbox "filter:" searchfilter ]
             if (=s $guirollovername "filter:") [
-                guitooltip "^faThis will only list matching servers. Allows to search for names and handles of connected players, currently played maps, modes and mutators, or server descriptions, ips and ports." 
+                guitooltip "^faFilter by player names or handles, current map, mode or mutators, server description, IP address or port." 
             ]
             guistrut 0.5
             guifield searchstrval 18 [searchstr = $searchstrval; searchfilter = 1] -1 0 "" 0 "^fd <enter search terms>" 1


### PR DESCRIPTION
Continuation of https://github.com/red-eclipse/base/pull/31
Allows to search also for maps, modes, mutators (the full names) and ip (the latter seems a bit strange, but was requested here http://redeclipse.net/forum/viewtopic.php?f=5&t=490&p=4216#p4212)
A bit of cleanup, too.