### PR TITLE
add experimental search for maps menu

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -77,8 +77,7 @@ mapsmenuiter = [
             curlist = (sortlist (? (>= $modeselected $modeidxplay) (getmaplist $modeselected $mutsselected (? (isonline) (listlen (listclients 1)) 0)) $allowmaps) a b [<s $a $b])
             filelist = (sortlist (listfiles maps mpz) a b [<s $a $b])
             if (&& (> (strlen $mapextra) 0) (= $searchfilter 1) ) [
-                matchlist = (listfilter i $curlist [(> (strstr $i $mapextra) -1)])
-                append matchlist (listfilter i $filelist [(> (strstr $i $mapextra) -1)])
+                matchlist = (listfilter i $filelist [(> (strstr $i $mapextra) -1)])
                 looplist lcurmap $matchlist [
                     append maplist $lcurmap
                     append mappath [maps/@lcurmap]
@@ -385,7 +384,7 @@ mapsmenu = [
                                         ] "." [
                                             guitext "maps from sauerbraten:"
                                         ] "-" [
-                                            guitext (format "allowed maps not matching ^"^fy%1^fw^"" $mapextra) 
+                                            guitext (format "maps not matching ^"^fy%1^fw^":" $mapextra) 
                                         ] "?" [
                                             break = 1
                                         ] () [
@@ -410,13 +409,13 @@ mapsmenu = [
                             ]
                             guilist [
                                 guitext "custom map or " 
-                                guicheckbox "map search" searchfilter 1 0 [resetmapgui = 1]
+                                guicheckbox "^fwmap search" searchfilter 1 0 [resetmapgui = 1]
                             ]
                             guilist [
                                 mapextraval = $mapextra
                                 mapextranum = $nummaps
                                 guiradio "" mapnum $mapextranum
-                                guifield mapextraval 34 [ mapextra = $mapextraval; mapnum = $mapextranum; resetmapgui = 1] -1 0 "" 0 "^fd<enter map name>" 1
+                                guifield mapextraval 34 [mapextra = $mapextraval; mapnum = $mapextranum; resetmapgui = 1] -1 0 "" 0 "^fd<enter map name>" 1
                             ]
                         ]
                         guislider mapindex 0 (max (- $nummaps $mapscount) 0) [] 1 1

--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -24,6 +24,7 @@ setpersist demofavs 1
 setcomplete demofavs 1
 resetmapgui = 1
 mapscount = 20
+searchfilter = 0
 
 mapsmenuinit = [
     modeselected = -1
@@ -74,6 +75,21 @@ mapsmenuiter = [
             mutsselected = (mutscheck $modeselected $mutsselected)
             mapfavs = (sortlist $mapfavs a b [<s $a $b])
             curlist = (sortlist (? (>= $modeselected $modeidxplay) (getmaplist $modeselected $mutsselected (? (isonline) (listlen (listclients 1)) 0)) $allowmaps) a b [<s $a $b])
+            filelist = (sortlist (listfiles maps mpz) a b [<s $a $b])
+            if (&& (> (strlen $mapextra) 0) (= $searchfilter 1) ) [
+                matchlist = (listfilter i $curlist [(> (strstr $i $mapextra) -1)])
+                append matchlist (listfilter i $filelist [(> (strstr $i $mapextra) -1)])
+                looplist lcurmap $matchlist [
+                    append maplist $lcurmap
+                    append mappath [maps/@lcurmap]
+                ]
+                if (> (listlen $matchlist) 0) [
+                    append maplist "-"
+                    append mappath "-"
+                    curlist = (listfilter i $curlist [(= (strstr $i $mapextra) -1)])
+                    filelist = (listfilter i $filelist [(= (strstr $i $mapextra) -1)])
+                ]
+            ]
             curprev = (sortlist (sublist $previousmaps 0 $maphistory) a b [<s $a $b])
             loop q 2 [
                 looplist lcurmap $curlist [
@@ -97,7 +113,6 @@ mapsmenuiter = [
                 append mappath [maps/@lcurmap]
             ]
             wantlist = 1
-            filelist = (sortlist (listfiles maps mpz) a b [<s $a $b])
             loop q 2 [
                 looplist lcurmap $filelist [
                     if (< (listfind mcurmap $maplist [strcmp $mcurmap $lcurmap]) 0) [
@@ -369,11 +384,13 @@ mapsmenu = [
                                             guitext "maps played recently:"
                                         ] "." [
                                             guitext "maps from sauerbraten:"
+                                        ] "-" [
+                                            guitext (format "allowed maps not matching ^"^fy%1^fw^"" $mapextra) 
                                         ] "?" [
                                             break = 1
                                         ] () [
                                             guilist [
-                                                guiradio $curmap mapnum $q
+                                                guiradio (strreplace $curmap $mapextra (format "^fs^fy%1^fS" $mapextra)) mapnum $q
                                                 guispring 1
                                                 guistayopen [
                                                     hasmap = (>= (indexof (? (= $modeselected $modeidxdemo) $demofavs $mapfavs) $curmap) 0)
@@ -391,12 +408,15 @@ mapsmenu = [
                                     ]
                                 ]
                             ]
-                            guilist [ guitext "custom map" ]
+                            guilist [
+                                guitext "custom map or " 
+                                guicheckbox "map search" searchfilter 1 0 [resetmapgui = 1]
+                            ]
                             guilist [
                                 mapextraval = $mapextra
                                 mapextranum = $nummaps
                                 guiradio "" mapnum $mapextranum
-                                guifield mapextraval 34 [mapextra = $mapextraval; mapnum = $mapextranum] -1 0 "" 0 "^fd<enter map name>"
+                                guifield mapextraval 34 [ mapextra = $mapextraval; mapnum = $mapextranum; resetmapgui = 1] -1 0 "" 0 "^fd<enter map name>" 1
                             ]
                         ]
                         guislider mapindex 0 (max (- $nummaps $mapscount) 0) [] 1 1


### PR DESCRIPTION
The custom map field can be used for searches (with a checkbox).
Matching maps are shown at the top (sort rather than filter).
Experimental, so maybe the implementation is rather inefficient.
I'll just put this here for review, in case it is useful.