### PR TITLE
help for basic mut, guihoverblend --> guinohitfx

### DIFF
--- a/config/menus/help.cfg
+++ b/config/menus/help.cfg
@@ -1,5 +1,4 @@
 newgui help [
-    guivisible [ guihoverblend 0.9 ]
     guilist [
         if ($isconnected) [
             guilist [
@@ -17,7 +16,7 @@ newgui help [
                     guilist [
                         guispring
                         looplist i (modetexlist $gamemode $mutators 1) [
-                            guiimage $i [showgui (substring @i 21)] 2
+                            guinohitfx [ guiimage $i [showgui (substring @i 21)] 2 ]
                         ]
                         guispring
                     ]
@@ -100,7 +99,6 @@ newgui support [
 
 newgui modes-mutators [
     guiheader "modes & mutators"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "GAME MODES & MODE MUTATORS" ] ]
     guistrut 0.5
     guicenter [ guitext "Red Eclipse has a variety of different game modes to choose from," ]
@@ -141,10 +139,9 @@ newgui modes-mutators [
 
 newgui demo [
     guiheader "demo mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "DEMO MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/spectator" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/spectator" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Spectate a recorded match from any player's perspective. Speed up or slow down the action," ]
     guicenter [ guitext "and view every key that any player presses to learn new strategy and see new opportunities!" ]
@@ -166,17 +163,16 @@ newgui demo [
 
 newgui editing [
     guiheader "edit mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "EDITING MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/editing" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/editing" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Create your own custom maps or edit an existing map using a wide variety of textures, models," ]
     guicenter [ guitext "entities and world variables. If your creation is worthy it could be included in Red Eclipse!" ]
     guicenter [
-        guiimage "textures/images/007" [] 10
+        guinohitfx [guiimage "textures/images/007" [] 10]
         guistrut 2.5
-        guiimage "textures/images/008" [] 10
+        guinohitfx [guiimage "textures/images/008" [] 10]
     ]
     guistrut -3
     guitab "tips & further reading"
@@ -197,17 +193,16 @@ newgui editing [
 
 newgui deathmatch [
     guiheader "deathmatch mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "DEATHMATCH MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/deathmatch" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/deathmatch" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Attack enemy players gathering frags, assists, sprees and other bonuses to score points." ]
     guicenter [ guitext "The team or individual with the most points at the end wins!" ]
     guicenter [
-        guiimage "textures/images/001" [] 10
+        guinohitfx [guiimage "textures/images/001" [] 10]
         guistrut 2.5
-        guiimage "textures/images/006" [] 10
+        guinohitfx [guiimage "textures/images/006" [] 10]
     ]
     guistrut -3
     guitab "tips & strategy"
@@ -230,17 +225,16 @@ newgui deathmatch [
 
 newgui capture [
     guiheader "capture-the-flag mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "CAPTURE-THE-FLAG MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/capture" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/capture" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Capture the enemy team's flag and return it to your base while defending your own flag from capture." ]
     guicenter [ guitext "Secure both flags at your base to score a point, the team with the most points at the end wins!" ]
     guicenter [
-        guiimage "textures/images/002" [] 10
+        guinohitfx [guiimage "textures/images/002" [] 10]
         guistrut 2.5
-        guiimage "textures/images/009" [] 10
+        guinohitfx [guiimage "textures/images/009" [] 10]
     ]
     guistrut -3
     guitab "tips & strategy"
@@ -270,19 +264,19 @@ newgui capture [
     guitab "mode-specific mutators"
     guifont "emphasis" [ guicenter [ guitext "QUICK MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/capturequick" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/capturequick" [] 2 ] ]
     guicenter [ guitext "Touching your own team's loose flag will instantly teleport it back to your base," ]
     guicenter [ guitext "instead of having to escort it there on foot." ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "DEFEND MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/capturedefend" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/capturedefend" [] 2 ] ]
     guicenter [ guitext "When your flag is taken from your base, you cannot pick it up." ]
     guicenter [ guitext "You must protect it from where it's dropped until the timer resets." ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "PROTECT MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/captureprotect" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/captureprotect" [] 2 ] ]
     guicenter [ guitext "Instead of scoring for returning an enemy flag to your base, you simply must" ]
     guicenter [ guitext "pick it up and hold onto it for 15 seconds to score. You may also carry your own" ]
     guicenter [ guitext "flag around while seeking out others." ]
@@ -290,18 +284,17 @@ newgui capture [
 
 newgui defend [
     guiheader "defend-and-control mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "DEFEND-AND-CONTROL MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/defend" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/defend" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Secure and defend control points scattered around the map by standing near them for a set period of time." ]
     guicenter [ guitext "Overthrow enemy control points then secure them for your own team to gain an advantage. Every secured" ]
     guicenter [ guitext "control point provides a steady stream of points, the team with the most points at the end wins!" ]
     guicenter [
-        guiimage "textures/images/003" [] 10
+        guinohitfx [guiimage "textures/images/003" [] 10]
         guistrut 2.5
-        guiimage "textures/images/010" [] 10
+        guinohitfx [guiimage "textures/images/010" [] 10]
     ]
     guistrut -3
     guitab "tips & strategy"
@@ -317,32 +310,31 @@ newgui defend [
     guitab "mode-specific mutators"
     guifont "emphasis" [ guicenter [ guitext "KING MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/defendking" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/defendking" [] 2 ] ]
     guicenter [ guitext "There is only one control point in this mutator, located near the center of the map." ]
     guicenter [ guitext "To make things harder, points are only given when players are in proximity to it." ]
     guicenter [ guitext "The objective: make your team king of the hill." ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "QUICK MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/defendquick" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/defendquick" [] 2 ] ]
     guicenter [ guitext "Control points are secured much more quickly in this mutator. When capturing enemy control" ]
     guicenter [ guitext "points there is no neutral state, the point is captured immediately for your team." ]
 ]
 
 newgui bomber [
     guiheader "bomber-ball mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "BOMBER-BALL MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/bomber" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/bomber" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Secure the bomber-ball and deliver it to the enemy base to destroy it, but watch the timer!" ]
     guicenter [ guitext (format "If the timer runs out, the ball will explode and you with it. Press %1 to throw it before this" (dobindsearch "affinity") ) ]
     guicenter [ guitext (format "happens, or hold %1 and lock target on a teammate to pass the ball, resetting the timer." (dobindsearch "affinity") ) ]
     guicenter [
-        guiimage "textures/images/004" [] 10
+        guinohitfx [guiimage "textures/images/004" [] 10]
         guistrut 2.5
-        guiimage "textures/images/011" [] 10
+        guinohitfx [guiimage "textures/images/011" [] 10]
     ]
     guistrut -3
     guitab "tips & strategy"
@@ -358,38 +350,37 @@ newgui bomber [
     guitab "mode-specific mutators"
     guifont "emphasis" [ guicenter [ guitext "HOLD MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/bomberhold" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/bomberhold" [] 2 ] ]
     guicenter [ guitext "Instead of bringing the ball to a goal, you earn points in this mutator by holding the ball as long as" ]
     guicenter [ guitext "possible. Killing an enemy will reset the explode timer. The ball will still explode when the timer runs" ]
     guicenter [ guitext "out however, resulting in drastic point loss, so throw it away or pass it to a teammate before this happens!" ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "BASKET MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/bomberbasket" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/bomberbasket" [] 2 ] ]
     guicenter [ guitext "Instead of bringing the ball to the goal on foot, you absolutely must throw it in to score." ]
     guicenter [ guitext "You also must be far enough away from the goal before attempting a shot!" ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "ATTACK MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/bomberattack" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/bomberattack" [] 2 ] ]
     guicenter [ guitext "One team spawns with the ball at their goal while all others try to prevent the" ]
     guicenter [ guitext "team from scoring at another goal. Afer a set time, the roles are switched." ]
 ]
 
 newgui race [
     guiheader "race mode"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "RACE MODE" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/race" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/race" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Race across maps set up as a course and complete more finished laps than opponents, carefully" ]
     guicenter [ guitext (format "managing your limited impulse and executing parkour moves with the %1 button. Reaching a" (dobindsearch "special") ) ]
     guicenter [ guitext "checkpoint will allow you to respawn from that spot." ]
     guicenter [
-        guiimage "textures/images/005" [] 10
+        guinohitfx [guiimage "textures/images/005" [] 10]
         guistrut 2.5
-        guiimage "textures/images/012" [] 10
+        guinohitfx [guiimage "textures/images/012" [] 10]
     ]
     guistrut -3
     guitab "tips & strategy"
@@ -409,29 +400,28 @@ newgui race [
     guitab "mode-specific mutators"
     guifont "emphasis" [ guicenter [ guitext "TIMED MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/racetimed" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/racetimed" [] 2 ] ]
     guicenter [ guitext "Instead of competing for the most number of laps, players" ]
     guicenter [ guitext "and teams compete for the fastest overall lap time." ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "ENDURANCE MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/raceendurance" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/raceendurance" [] 2 ] ]
     guicenter [ guitext "Your impulse meter is not restored upon death or checkpoint respawn." ]
-    guicenter [ guitext "Also slows down impulse regeneration, so plan your route carefully!" ]
+    guicenter [ guitext "Impulse management is essential here, so plan your route carefully!" ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "GAUNTLET MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/racegauntlet" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/racegauntlet" [] 2 ] ]
     guicenter [ guitext "One team races to reach the goal and score points, while the other teams try to" ]
     guicenter [ guitext "attack them before they can reach the end. Afer a set time, the roles are switched." ]
 ]
 
 newgui multi [
     guiheader "multi mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "MULTI MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/multi" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/multi" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Play with four teams instead of two (by default Kappa & Sigma, in addition to Alpha & Omega)." ]
     guistrut 2
@@ -448,10 +438,9 @@ newgui multi [
 
 newgui ffa [
     guiheader "free-for-all mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "FREE-FOR-ALL MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/ffa" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/ffa" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "There are no teams, just every player for themselves in a Free-for-All showdown!" ]
     guicenter [ guitext "This mutator is not available in Capture-the-Flag or Defend-and-Control modes." ]
@@ -473,10 +462,9 @@ newgui ffa [
 
 newgui coop [
     guiheader "co-op mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "CO-OP MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/coop" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/coop" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "All human players are forced onto the same team, battling against a team of" ]
     guicenter [ guitext "bots... and there are more of them than there are of you!" ]
@@ -498,10 +486,9 @@ newgui coop [
 
 newgui instagib [
     guiheader "instagib mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "INSTAGIB MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/instagib" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/instagib" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Players spawn with only 1 HP, so any hit is lethal. Unless the Medieval or Kaboom mutators are" ]
     guicenter [ guitext "also selected, players only spawn with the rifle. All rifle spawns on the map become grenade spawns." ]
@@ -521,10 +508,9 @@ newgui instagib [
 
 newgui medieval [
     guiheader "medieval mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "MEDIEVAL MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/medieval" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/medieval" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Players only spawn with swords. All sword spawns on the map become grenade spawns." ]
     guistrut 2
@@ -543,10 +529,9 @@ newgui medieval [
 
 newgui kaboom [
     guiheader "kaboom mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "KABOOM MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/kaboom" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/kaboom" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Players only spawn with grenades and mines. Grenades and mines reload in" ]
     guicenter [ guitext "this mutator like a normal loadout weapon, though your carry capacity remains default." ]
@@ -566,10 +551,9 @@ newgui kaboom [
 
 newgui duel [
     guiheader "duel mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "DUEL MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/duel" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/duel" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Only two players spawn at a time, the rest are placed in a queue. The winning team or individual" ]
     guicenter [ guitext "continues to the next round, while the loser always gets placed at the end of the queue." ]
@@ -591,10 +575,9 @@ newgui duel [
 
 newgui survivor [
     guiheader "survivor mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "SURVIVOR MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/survivor" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/survivor" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "All players spawn as normal, but there is no health regeneration. The last player or team" ]
     guicenter [ guitext "standing wins the round. Players that die are placed in a queue to respawn in the next round." ]
@@ -614,10 +597,9 @@ newgui survivor [
 
 newgui classic [
     guiheader "classic mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "CLASSIC MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/classic" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/classic" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Everyone spawns with only one spawn weapon (by default, the pistol). The rest of" ]
     guicenter [ guitext "the weapons can be found at spawn points, scattered around the map." ]
@@ -637,10 +619,9 @@ newgui classic [
 
 newgui onslaught [
     guiheader "onslaught mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "ONSLAUGHT MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/onslaught" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/onslaught" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Enemy drones and sentry turrets spawn in the middle of the action." ]
     guicenter [ guitext "If one of them kills you, you lose points!" ]
@@ -660,10 +641,9 @@ newgui onslaught [
 
 newgui freestyle [
     guiheader "freestyle mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "FREESTYLE MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/freestyle" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/freestyle" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "There are no impulse limits, the impulse meter is" ]
     guicenter [ guitext "never depleted so get your parkour on!" ]
@@ -683,10 +663,9 @@ newgui freestyle [
 
 newgui vampire [
     guiheader "vampire mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "VAMPIRE MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/vampire" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/vampire" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Damage dealt to enemies causes you to regenerate the same amount of health." ]
     guicenter [ guitext "The default cap in this mutator is 300 health." ]
@@ -706,10 +685,9 @@ newgui vampire [
 
 newgui resize [
     guiheader "resize mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "RESIZE MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/resize" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/resize" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "As your health decreases, you become smaller and your speed decreases." ]
     guicenter [ guitext "The opposite is true when you gain health." ]
@@ -729,10 +707,9 @@ newgui resize [
 
 newgui hard [
     guiheader "hard mutator"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "HARD MUTATOR" ] ]
     guistrut 0.25
-    guicenter [ guiimage "textures/modes/hard" [] 2 ]
+    guicenter [ guinohitfx [ guiimage "textures/modes/hard" [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext "Players spawn without a radar." ]
     guicenter [ guitext "There is no health regeneration in this mutator." ]
@@ -748,6 +725,23 @@ newgui hard [
     guitext "Remember, not only have you lost track of players and teammates, you also won't see explosives (including the rocket) spawn on your radar. Check their spawn points frequently." point -1 -1 2100
     guistrut 0.25
     guitext "For a truly brutal Red Eclipse, try a Free-for-All Freestyle Onslaught Hard Deathmatch on a large map." point -1 -1 2100
+]
+
+newgui basic [
+    guiheader "basic mutator"
+    guifont "emphasis" [ guicenter [ guitext "BASIC MUTATOR" ] ]
+    guistrut 0.25
+    guicenter [ guinohitfx [ guiimage "textures/modes/basic" [] 2 ] ]
+    guistrut 0.25
+    guicenter [ guitext "No collectable items will spawn in the arena." ]
+    guistrut 2
+    guifont "emphasis" [ guicenter [ guitext "TIPS & STRATEGY" ] ]
+    guistrut 0.25
+    guitext "If you want a match without grenades, mines and rockets, try the basic mutator." point -1 -1 2100
+    guistrut 0.25
+    guitext "Forget about map control: Focus on your enemies and team objective!" point -1 -1 2100
+    guistrut 0.25
+    guitext "For a showdown with pistols and parkour only, combine the classic and basic mutators." point -1 -1 2100
 ]
 
 newgui capturedefend [
@@ -890,7 +884,6 @@ newgui account-levels [
 
 newgui parkour [
     guiheader "parkour"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "PARKOUR" ] ]
     guistrut 0.25
     guicenter [ guitext "In Red Eclipse, the art of parkour replaces your player's normal fatigue and damage from falling." ]
@@ -949,7 +942,6 @@ newgui rules [
 
 newgui scoring [
     guiheader "scoring"
-    guivisible [ guihoverblend 0.9 ]
     guifont "emphasis" [ guicenter [ guitext "SCORING SYSTEM" ] ]
     guistrut 0.5
     guicenter [ guitext "Scoring in Red Eclipse is handled using a very intricate Deathmatch Scoring System, with normal point gain and loss as well as bonus points attainable through combo streaks or sprees. While team scores in other game modes are objective based, the system described here still applies to scores of individual players." "" -1 -1 2100 ]
@@ -968,10 +960,9 @@ newgui scoring [
 
 newgui point-gain [
     guiheader "point gain"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "FRAGS & ASSISTS" ] ]
     guistrut 0.25
-    guicenter [ guiimage textures/dead [] 2 ]
+    guicenter [ guinohitfx [ guiimage textures/dead [] 2 ] ]
     guistrut 0.25
     guicenter [ guitext (format "The core objective of the entire game, land the killing shot on an enemy to earn a frag and ^fs^fg%1^fS points. If you did not kill an opponent, but chipped in with a hit over the previous ^fs^fg%2^fS seconds before death, your name is mentioned in the obituary line for an assist, and you receive one point. Multiple players can receive assists on the same kill, and in a team game this can result in multiple points from assists for the same team. Also note that it doesn't only count damage-dealing attacks, but some weapons that result in near-misses will still give off shockwaves that push players around, and one of those, no matter how slight, still qualifies you to receive an assist. This leads to the somewhat odd result that players can still earn assists even in Instagib mode." $fragbonus (*f 0.001 $assistkilldelay)) "" -1 -1 2100 ]
     guistrut 1
@@ -990,23 +981,21 @@ newgui point-gain [
 
 newgui point-penalties [
     guiheader "point penalties"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "TEAM KILLS" ] ]
-    guicenter [ guiimage textures/warning [] 2 0 "" [] 0xff0000 ]
+    guicenter [ guinohitfx [ guiimage textures/warning [] 2 ] 0 "" [] 0xff0000 ]
     guicenter [ guitext (format "In team games, you have teammates for a reason, so don't kill them! Doing so brings a harsh penalty: ^fs^fr%1^fS points are lost for each team kill. There is only one exception: No points are lost for kills attributed to residual damage (bleeding, electric shock, or burn). Avoid team kills at all costs, as too many will get you automatically kicked and banned from the server!" (* $teamkillpenalty $fragbonus) ) "" -1 -1 2100 ]
     guistrut 0.25
     guifont "emphasis" [ guicenter [ guitext "SUICIDE" ] ]
-    guicenter [ guiimage textures/dead [] 2 ]
+    guicenter [ guinohitfx [ guiimage textures/dead [] 2 ] ]
     guicenter [ guitext (format "If you hit yourself with your own weapon and run out of health (this includes exploding yourself with grenades or hitting your own mines), this counts as a team kill and is subject to the above scoring. However, there are other ways to die both accidental and on purpose: jumping into an abyss or off the edge of the map, a lava pit or other map hazard (causing you to collide with invisible death material). Also, you can press %1 at any time to immediately commit suicide. None of these options are desirable, bringing a penalty of -3 (pressing r%1 while holding a grenade brings a penalty of ^fs^fr%2^fS points)." (dobindsearch "suicide") (* $fragbonus $teamkillpenalty) ) "" -1 -1 2100 ]
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "ENEMIES" ] ]
-    guicenter [ guiimage textures/modes/onslaught [] 2 ]
+    guicenter [ guinohitfx [ guiimage textures/modes/onslaught [] 2 ] ]
     guicenter [ guitext (format "If the Onslaught mutator is selected, and if the chosen map provides for it by placing the appropriate spawn points, a neutral army of grunts, drones, and/or turrets will swarm the arena. These forces (collectively and internally known as 'enemies') do not have a place on the scoreboard, but if one of them administers a frag, the unfortunate victim loses ^fs^fr%1^fS points from their score. Enemies can also be listed for assists, but these are totally inconsequential; there is no further penalty regardless of how many enemies chip in with assists. Killing an enemy adds to your frag count, but it isn't announced in the obituary feed, and it only provides ^fs^fr%2^fS point instead of the usual ^fs^fr%3^fS. If the kill is a head shot (not applicable against turrets), you can earn a second point from that, but otherwise kills against enemies are not taken into account for any other bonuses such as Double Kill or Carnage." 3 $enemybonus $fragbonus ) "" -1 -1 2100 ]
 ]
 
 newgui combos [
     guiheader "Combos and killing sprees"
-    guivisible [ guihoverblend 0 ]
     guistrut -2
     guicenter [ guiimage textures/rewards/double [] 4; guiimage textures/rewards/triple [] 4; guiimage textures/rewards/multi [] 4 ]
     guistrut -2
@@ -1026,7 +1015,6 @@ newgui combos [
 
 newgui dominating [
     guiheader "dominating and revenge"
-    guivisible [ guihoverblend 0 ]
     //guifont "emphasis" [ guicenter [ guitext "DOMINATING" ] ]
     guistrut -1.5
     guicenter [ guiimage textures/rewards/dominate [] 4 ]
@@ -1042,7 +1030,6 @@ newgui dominating [
 
 newgui objective-scores [
     guiheader "Player scores in objective based games"
-    guivisible [ guihoverblend 0 ]
     guitext "In objective based team games, frags and bonus elements of the Deathmatch Scoring System have no impact on the team scores. However, this scoring system is still applied to individual player scores, while certain actions related to the team objective give additional bonus points." "" -1 -1 2100
     guistrut 0.5
     guifont "emphasis" [ guicenter [ guitext "CAPTURE-THE-FLAG" ] ]
@@ -1057,7 +1044,6 @@ newgui objective-scores [
 
 newgui various-scores [
     guiheader "Scoring in Duel, Survivor and Race games"
-    guivisible [ guihoverblend 0 ]
     guifont "emphasis" [ guicenter [ guitext "DUEL & SURVIVOR" ] ]
     guitext "If either one of these modes are selected, regardless of game type, players' scores are replaced by a different system that tracks the number of rounds they've scored in, and thus their contribution to the team score if it's a team game. In a survivor deathmatch, the winning team only receives ^fs^fg1^fS point per round regardless of how many players are still alive, but each surviving player at the end gets a point to their own credit. The one exception is that multi-survivor Capture the Flag offers the unique possibility of earning up to ^fs^fg3^fS points per round (by capturing all 3 other flags simultaneously)." "" -1 -1 2100
     guistrut 0.5


### PR DESCRIPTION
Add a help menu for the new *basic* mutator
Remove all occurrences of *guihoverblend*, which was an ugly workaround.
Use *guinohitfx* on all non-button images.
Endurance mut does actually not slow down regeneration.