### PR TITLE
fix guitext alignment in options.cfg

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -170,7 +170,7 @@ newgui options_graphics [
                         guistrut 1
                         guitext "^fAintense" radiodisable
                     ] ]
-                ] [ guitext "" ] // spacer
+                ] [ guitext " " ] // spacer
             ]
             guilist [   // motion blur
                 if (&& $motionblur $usetexrect) [
@@ -226,7 +226,7 @@ newgui options_graphics [
                     guitext "^fAhigh quality" radiodisable
                 ] ]
             ]
-            guitext ""  // spacer for glass reflection
+            guitext " "  // spacer for glass reflection
             guilist [   // decals
                 if $decals [
                     guiradio "^fgmedium quality" maxdecaltris 1024
@@ -238,7 +238,7 @@ newgui options_graphics [
                     guitext "^fAhigh quality" radiodisable
                 ] ]
             ]
-            guitext "" // spacer for t-joints
+            guitext " " // spacer for t-joints
             guilist [   // textures
                 guiradio "^fglow quality" maxtexsize 256
                 guistrut 1
@@ -556,7 +556,7 @@ newgui options_ui [
                 guitext "toggles visibility of player team above head"
             ] () [
                 guitext "hover over an item for a description"
-                guitext ""
+                guitext " "
             ]
         ]
     ]


### PR DESCRIPTION
replace all **guitext ""** with **guitext " "**, so the columns are aligned nicely again.