### PR TITLE
show race route via help menu

### DIFF
--- a/config/menus/help.cfg
+++ b/config/menus/help.cfg
@@ -26,6 +26,16 @@ newgui help [
                             guicenter [ guitext ( concatword  "^fy" (mutsdesc $gamemode (<< 1 $i) 3) ) ]
                         ]
                     ]
+                    if (= $gamemode $modeidxrace) [
+                            guistrut 0.5
+                            guicenter [
+                                guibutton "indicate route: " [saycommand "/routecolour "] [] "" $routecolour
+                                guiradio "off " routeid -1
+                                guiradio "basic " routeid 0
+                                guiradio "advanced " routeid 1
+
+                            ]
+                    ]
                 ]
             ]
             guistrut 0.5


### PR DESCRIPTION
So, we have two routes for every official map, but no menu option yet to show them, right?
I guess the help (F1) menu is a good place.