### PR TITLE
Fix loadout menu for tips and key binding menu

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -11,7 +11,7 @@ newcompass menus "textures/menu" [
     compass "vote" [showgui maps 2]
     compass "servers" [showgui servers]
     compass "team" [showgui team]
-    if (&& [> (mutators) 0] [& (mutators) 0x0020]) [compass "loadout" [showgui loadout]]
+    if (&& [> (mutators) 0] [& (mutators) 0x0020]) [compass "loadout" [showgui profile 2]]
     compass "options" [showgui options]
 ]
 

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1024,7 +1024,7 @@ bindactions = [
     "primary" "secondary" "reload" "use" "jump" "walk" "crouch" "special" "drop" "affinity"
     "weapon 1" "weapon 2" "weapon 3" "weapon 4" "weapon 5" "weapon 6" "weapon 7" "weapon 8" "weapon 9" "weapon 10"
     "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui loadout" "showgui team"
+    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
     "showcompass voice" "showcompass team"
 ]
 bindtitles = [
@@ -1039,7 +1039,7 @@ bindtitles = [
 specbindactions = [
     forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
     "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui loadout" "showgui team"
+    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
     "showcompass voice" "showcompass team"
 ]
 specbindtitles = [
@@ -1052,7 +1052,7 @@ specbindtitles = [
 waitbindactions = [
     forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
     "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui loadout" "showgui team"
+    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
     "showcompass voice" "showcompass team"
 ]
 waitbindtitles = [

--- a/config/tips.cfg
+++ b/config/tips.cfg
@@ -20,7 +20,7 @@ resettips = [
     addtip (format "press %1 to open the ^fs^fyhelp menu^fS at any time" (dobindsearch "showgui help"))
     addtip (format "press %1 to make a ^fs^fymap selection^fS" (dobindsearch "showgui maps 1"))
     addtip (format "press %1 to show the ^fs^fyserver list^fS" (dobindsearch "showservers"))
-    addtip (format "press %1 to change your ^fs^fyloadout weapons^fS" (dobindsearch "showgui loadout"))
+    addtip (format "press %1 to change your ^fs^fyloadout weapons^fS" (dobindsearch "showgui profile 2"))
     addtip (format "press %1 to ^fs^fychange teams^fS" (dobindsearch "showgui team"))
     addtip "when you're ^fs^foon fire^fS you can ^fs^fcjump in water^fS to put yourself out, crouch if necessary"
     addtip "you're ^fs^fyless accurate^fS when ^fs^fyjumping^fS and ^fs^fymoving^fS, stop for a perfect shot"

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1428,7 +1428,7 @@ namespace hud
                         }
                         if(m_loadout(game::gamemode, game::mutators))
                         {
-                            SEARCHBINDCACHE(loadkey)("showgui loadout", 0);
+                            SEARCHBINDCACHE(loadkey)("showgui profile 2", 0);
                             pushfont("little");
                             ty += draw_textx("Press %s to \fs%s\fS loadout", tx, ty, tr, tg, tb, tf, TEXT_CENTERED, -1, tw, loadkey, target->loadweap.empty() ? "\fzoyselect" : "change");
                             popfont();

--- a/src/game/scoreboard.cpp
+++ b/src/game/scoreboard.cpp
@@ -389,7 +389,7 @@ namespace hud
                                             }
                                             if(m_loadout(game::gamemode, game::mutators))
                                             {
-                                                SEARCHBINDCACHE(loadkey)("showgui loadout", 0);
+                                                SEARCHBINDCACHE(loadkey)("showgui profile 2", 0);
                                                 uicenterlist(g, g.textf("Press %s to \fs%s\fS loadout", 0xFFFFFF, NULL, 0, -1, loadkey, game::player1->loadweap.empty() ? "\fzoyselect" : "change"));
                                             }
                                             if(m_fight(game::gamemode) && m_team(game::gamemode, game::mutators))


### PR DESCRIPTION
The problem this pull request solves is that keys that are bind in gui to open loadout menu dont work and dont show up in tips.