### PR TITLE
enhance loadout menu

### DIFF
--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -1,12 +1,11 @@
 profilebuttons = [
-    guicenter [ guifont "emphasis" [
+    guilist [ guifont "emphasis" [
+        guistrut 2
         guibutton "^fgok" [
             setinfo $playerprevname $playerprevcolour $playerprevmodel $playerprevvanity $playerprevlweap
             cleargui 1
         ] []
-        guistrut 0.5
-        guispring 1
-        guistrut 0.5
+        guistrut 3
         if (needname) [
             guibutton "^fomain menu" [showgui main]
         ] [
@@ -16,7 +15,7 @@ profilebuttons = [
 ]
 
 profilepreview = [
-    guiplayerpreview $playerprevmodel $playerprevcolour $playerprevteam $playerprevweap $playerprevvanity [playerprevinherit = 1; showgui playerprev] 7.5 1 1
+    guiplayerpreview $playerprevmodel $playerprevcolour $playerprevteam $playerprevweap $playerprevvanity [playerprevinherit = 1; showgui playerprev] 7.6 1 1
 ]
 
 playerprevinherit = 0
@@ -116,6 +115,40 @@ newgui profile [
     guitab "loadout"
     guibox [ profilepreview ] [
         guilist [
+            guilist [
+                guispring 1
+                guicenter [ guitext "select favourite weapons" ]
+                guistrut 0.5
+                if (= $getplayerstate 0) [
+                    guicenter [ guitext "^faNOTE: Weapon changes " "textures/dead"]
+                    guicenter [ guitext "^fatake effect ^fzoyafter ^farespawn!"]
+                    guistrut 0.5
+                ]
+                guifont "little" [
+                    guicenter [ guitext (format "you can carry ^fs^fc%1^fS %2" $maxcarry (? (= $maxcarry 1) "weapon" "weapons")) ]
+                ]
+                guistrut 0.5
+                guilist [
+                    guibackground -1 0 0xffffff 1 1
+                    guistrut 1
+                    guilist [
+                        guifont "little" [
+                            guistrut 0.5
+                            guicenter [ guicheckbox "show all weapon slots" loadweapall ]
+                            guicenter [ guitext "^faif a weapon is not available, the" ]
+                            guicenter [ guitext "^fanext one in the list will be used" ]
+                            guistrut 0.5
+                        ]
+                    ]
+                    guistrut 1
+                ]
+                guistrut 1
+                guifont "little" [
+                    guicenter [ guicheckbox "pick a loadout every new game" showloadoutmenu ]
+                ]
+                guispring 1
+            ]
+            guistrut 2
             guilist [ 
                 guibackground
                 guicenter [
@@ -151,63 +184,23 @@ newgui profile [
                             if $al [ gdw = (+ $gdw 1) ]
                         ]
                         if (! $loadweapall) [
+                            guistrut 1
                             guilist [
-                                guinohitfx [
-                                    guilist [
-                                        loop w1 (- $weapidxloadout $maxcarry) [
-                                            guistrut 0.125
-                                            guiimage textures/blank [] 0.75
-                                            guistrut 0.125
-                                        ]
-                                    ]
-                                ]
+                                guistrut 1.5 
                                 guispring 1
                                 guicenter [guibutton "random" [loadweaps 0 0] [loadweaps 1 0]]
                                 guispring 1
                                 loop w1 $weapidxloadout [
                                     w4 = (+ $w1 $weapidxoffset)
                                     w5 = (at $weapname $w4)
-                                    guicenter [guibutton $w5 [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]]
+                                    guibutton $w5 [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]
                                     guispring 1
                                 ]    
                             ]    
+                            guistrut 1
                         ]    
                     ]
                 ]
-            ]
-            guistrut 2
-            guilist [
-                guispring 1
-                guicenter [ guitext "select favourite weapons" ]
-                guistrut 0.5
-                if (= $getplayerstate 0) [
-                    guicenter [ guitext "^faNOTE: Weapon changes " "textures/dead"]
-                    guicenter [ guitext "^fatake effect ^fzoyafter ^farespawn!"]
-                    guistrut 0.5
-                ]
-                guifont "little" [
-                    guicenter [ guitext (format "you can carry ^fs^fc%1^fS %2" $maxcarry (? (= $maxcarry 1) "weapon" "weapons")) ]
-                ]
-                guistrut 0.5
-                guilist [
-                    guibackground -1 0 0xffffff 1 1
-                    guistrut 1
-                    guilist [
-                        guifont "little" [
-                            guistrut 0.5
-                            guicenter [ guicheckbox "show all weapon slots" loadweapall ]
-                            guicenter [ guitext "^faif a weapon is not available, the" ]
-                            guicenter [ guitext "^fanext one in the list will be used" ]
-                            guistrut 0.5
-                        ]
-                    ]
-                    guistrut 1
-                ]
-                guistrut 1
-                guifont "little" [
-                    guicenter [ guicheckbox "pick a loadout every new game" showloadoutmenu ]
-                ]
-                guispring 1
             ]
         ]
     ] [ profilebuttons ]

--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -1,6 +1,6 @@
 profilebuttons = [
     guilist [ guifont "emphasis" [
-        guistrut 2
+        guistrut 10
         guibutton "^fgok" [
             setinfo $playerprevname $playerprevcolour $playerprevmodel $playerprevvanity $playerprevlweap
             cleargui 1
@@ -56,22 +56,6 @@ newgui playerprev [
     ]
 ]
 
-loadweapall = 0
-loadweaps = [
-    lwa = ""
-    lwl = (listlen $playerprevlweap)
-    lwo = (? (> $lwl $arg1) (at $playerprevlweap $arg1) -1)
-    loop lw2 $weapidxloadout [
-        if (= $lw2 $arg1) [
-            lwa = (? $lw2 (concat $lwa $arg2) $arg2)
-        ] [
-            lw3 = (? (> $lwl $lw2) (at $playerprevlweap $lw2) -1)
-            if (&& $lw3 (= $arg2 $lw3)) [ lw3 = $lwo ]
-            lwa = (? $lw2 (concat $lwa $lw3) $lw3)
-        ]
-    ]
-    if (listlen $lwa) [ playerprevlweap = $lwa ]
-]
 
 newgui profile [
     guibox [ profilepreview ] [
@@ -115,92 +99,46 @@ newgui profile [
     guitab "loadout"
     guibox [ profilepreview ] [
         guilist [
-            guilist [
-                guispring 1
-                guicenter [ guitext "select favourite weapons" ]
+            guilist [ 
+                guicenter [ guitext "Sort the weapons according to your preference" ]
                 guistrut 0.5
+                guicenter [
+                    guistayopen [
+                        loop i $weapidxitem [
+                            guilist [
+                                wi = (at $playerprevlweap $i)
+                                if (< $wi 2) [
+                                    wn = "random"
+                                    wt = "textures/question"
+                                ] [    
+                                    wn = (at $weapname $wi)
+                                    wt = (? (allowedweap $wi) [textures/weapons/@[wn]] [textures/warning])
+                                ]
+                                guiimage $wt [
+                                    playerprevlweap = (concat @wi (listdel $playerprevlweap @wi))
+                                ] 1.40 0 "" [
+                                    playerprevlweap = (concat (listdel $playerprevlweap @wi) @wi)
+                                ] $[@[wn]colour]
+                                guicenter [ guifont "little" [ guitext $wn "" $[@[wn]colour]]]
+                            ]    
+                        ]
+                    ]
+                ]
+                guistrut 1.5
                 if (= $getplayerstate 0) [
-                    guicenter [ guitext "^faNOTE: Weapon changes " "textures/dead"]
-                    guicenter [ guitext "^fatake effect ^fzoyafter ^farespawn!"]
+                    guicenter [ guitext "^faNOTE: Weapon changes take effect ^fzoyafter ^farespawn!" "textures/dead"]
                     guistrut 0.5
                 ]
                 guifont "little" [
                     guicenter [ guitext (format "you can carry ^fs^fc%1^fS %2" $maxcarry (? (= $maxcarry 1) "weapon" "weapons")) ]
-                ]
-                guistrut 0.5
-                guilist [
-                    guibackground -1 0 0xffffff 1 1
-                    guistrut 1
-                    guilist [
-                        guifont "little" [
-                            guistrut 0.5
-                            guicenter [ guicheckbox "show all weapon slots" loadweapall ]
-                            guicenter [ guitext "^faif a weapon is not available, the" ]
-                            guicenter [ guitext "^fanext one in the list will be used" ]
-                            guistrut 0.5
-                        ]
-                    ]
-                    guistrut 1
+                    guicenter [ guitext "if a weapon is not available, the next one in the list will be used"]
+                    guicenter [ guitext "you can right-click a weapon to move it to the end of the list" ]
                 ]
                 guistrut 1
                 guifont "little" [
                     guicenter [ guicheckbox "pick a loadout every new game" showloadoutmenu ]
                 ]
                 guispring 1
-            ]
-            guistrut 2
-            guilist [ 
-                guibackground
-                guicenter [
-                    guistayopen [
-                        gdw = 0
-                        gdl = (listlen $playerprevlweap)
-                        loop w2 (? $loadweapall $weapidxloadout $maxcarry) [
-                            w3 = (? (> $gdl $w2) (at $playerprevlweap $w2) -1)
-                            hi = (mod $w2 2)
-                            al = (|| (= $w3 0) (allowedweap $w3))
-                            guilist [
-                                guibackground (? (&& $al (< $gdw $maxcarry)) 0x303030 0x000000)
-                                guistrut 0.25
-                                guicenter [ guitext (format "%1%2" (? $hi "^fd" "^fw") (+ $w2 1)) ]
-                                guistrut 0.5
-                                guilist [
-                                    if (= $w3 0) [ guibackground 0xFFFFFF 0.01 0xFFFFFF 1 1 ]
-                                    guistrut 0.125
-                                    guiimage [textures/question] [loadweaps @w2 0] 0.75 0 [textures/blank] [] (? (= $w3 0) 0xFFFFFF 0x808080)
-                                    guistrut 0.125
-                                ] 
-                                loop w1 $weapidxloadout [
-                                    w4 = (+ $w1 $weapidxoffset)
-                                    w5 = (at $weapname $w4)
-                                    guilist [
-                                        if (= $w3 $w4) [ guibackground 0xFFFFFF 0.01 $[@[w5]colour] 1 1 ]
-                                        guistrut 0.125
-                                        guiimage (? (allowedweap $w4) [textures/weapons/@w5] [textures/warning]) [loadweaps @w2 @w4] 0.75 0 [textures/blank] [] (? (= $w3 $w4) $[@[w5]colour] 0x808080)
-                                        guistrut 0.125
-                                    ] 
-                                ]
-                            ]
-                            if $al [ gdw = (+ $gdw 1) ]
-                        ]
-                        if (! $loadweapall) [
-                            guistrut 1
-                            guilist [
-                                guistrut 1.5 
-                                guispring 1
-                                guicenter [guibutton "random" [loadweaps 0 0] [loadweaps 1 0]]
-                                guispring 1
-                                loop w1 $weapidxloadout [
-                                    w4 = (+ $w1 $weapidxoffset)
-                                    w5 = (at $weapname $w4)
-                                    guibutton $w5 [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]
-                                    guispring 1
-                                ]    
-                            ]    
-                            guistrut 1
-                        ]    
-                    ]
-                ]
             ]
         ]
     ] [ profilebuttons ]
@@ -259,11 +197,7 @@ newgui profile [
             playerprevmodel = (getplayermodel)
             playerprevvanity = (getplayervanity)
         ]
-        playerprevlweap = ""
-        break = 0
-        loopwhile i $weapidxloadout [= $break 0] [
-            q = (getloadweap $i)
-            if (< $q 0) [ break = 1 ] [ playerprevlweap = (? $i (concat $playerprevlweap $q) $q) ]
-        ]
+        // this makes sure all weapon types and two random slots (0 and 1) are in the loadout list (but no -1 tail).
+        playerprevlweap = (concat (listdel $playerloadweap -1) (listdel (loopconcat i $weapidxitem [$i]) $playerloadweap))
     ]
 ]

--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -57,6 +57,7 @@ newgui playerprev [
     ]
 ]
 
+loadweapall = 0
 loadweaps = [
     lwa = ""
     lwl = (listlen $playerprevlweap)
@@ -121,7 +122,7 @@ newgui profile [
                     guistayopen [
                         gdw = 0
                         gdl = (listlen $playerprevlweap)
-                        loop w2 $weapidxloadout [
+                        loop w2 (? $loadweapall $weapidxloadout $maxcarry) [
                             w3 = (? (> $gdl $w2) (at $playerprevlweap $w2) -1)
                             hi = (mod $w2 2)
                             al = (|| (= $w3 0) (allowedweap $w3))
@@ -149,6 +150,28 @@ newgui profile [
                             ]
                             if $al [ gdw = (+ $gdw 1) ]
                         ]
+                        if (! $loadweapall) [
+                            guilist [
+                                guinohitfx [
+                                    guilist [
+                                        loop w1 (- $weapidxloadout $maxcarry) [
+                                            guistrut 0.125
+                                            guiimage textures/blank [] 0.75
+                                            guistrut 0.125
+                                        ]
+                                    ]
+                                ]
+                                guispring 1
+                                guicenter [guibutton "random" [loadweaps 0 0] [loadweaps 1 0]]
+                                guispring 1
+                                loop w1 $weapidxloadout [
+                                    w4 = (+ $w1 $weapidxoffset)
+                                    w5 = (at $weapname $w4)
+                                    guicenter [guibutton $w5 [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]]
+                                    guispring 1
+                                ]    
+                            ]    
+                        ]    
                     ]
                 ]
             ]
@@ -157,15 +180,30 @@ newgui profile [
                 guispring 1
                 guicenter [ guitext "select favourite weapons" ]
                 guistrut 0.5
+                if (= $getplayerstate 0) [
+                    guicenter [ guitext "^faNOTE: Weapon changes " "textures/dead"]
+                    guicenter [ guitext "^fatake effect ^fzoyafter ^farespawn!"]
+                    guistrut 0.5
+                ]
                 guifont "little" [
                     guicenter [ guitext (format "you can carry ^fs^fc%1^fS %2" $maxcarry (? (= $maxcarry 1) "weapon" "weapons")) ]
                 ]
                 guistrut 0.5
-                guifont "little" [
-                    guicenter [ guitext "^faif a weapon is not available, the" ]
-                    guicenter [ guitext "^fanext one in the list will be used" ]
+                guilist [
+                    guibackground -1 0 0xffffff 1 1
+                    guistrut 1
+                    guilist [
+                        guifont "little" [
+                            guistrut 0.5
+                            guicenter [ guicheckbox "show all weapon slots" loadweapall ]
+                            guicenter [ guitext "^faif a weapon is not available, the" ]
+                            guicenter [ guitext "^fanext one in the list will be used" ]
+                            guistrut 0.5
+                        ]
+                    ]
+                    guistrut 1
                 ]
-                guistrut 2
+                guistrut 1
                 guifont "little" [
                     guicenter [ guicheckbox "pick a loadout every new game" showloadoutmenu ]
                 ]


### PR DESCRIPTION
on http://redeclipse.net/forum/viewtopic.php?f=4&t=647 @shirepirate wrote:
>  the way loadout is handled currently, it's not very intuitive, rather confusing and even at times frustrating.
> [...] after changing a loadout in-game, players are left with little or no explanation that it won't take effect until they respawn

* notify players about respawn for weapon change if their state is *alive*
* bring back the option to toggle display of all weapon slots
* show weapon names if extra slots are hidden
* keep a nice layout (with another framed box)