### PR TITLE
Bot command quick-chat menu

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -2,6 +2,7 @@ newcompass main "textures/menu" [
     compass "menus" [showcompass menus]
     compass "voice" [showcompass voice]
     compass "team" [showcompass team]
+    compass "bot" [showcompass bot]
     compass "clear" [clearcompass]
 ]
 
@@ -39,5 +40,54 @@ newcompass team "textures/hud/voices" [
     compass "common voice actions" "V" [showcompass voice]
 ]
 
+newcompass bot "textures/hud/voices" [
+    if (|| (= (gamemode) 0) (= (gamemode) 6)) [ // edit or race
+    ] [
+        compass "forget" [sayteam "bots forget"]
+        if (= (gamemode) 2) [ // dm
+            compass " " [ ]                                      // attack affinity
+            compass " " [ ]                                      // attack location
+            //compass " " [ ]                                      // attack name
+            compass "defend me"   [sayteam "bots defend me"]     // defend me
+            compass "defend here" [sayteam "bots defend here"]   // defend here
+            compass " " [ ]                                      // defend affinity
+            compass " " [ ]                                      // defend location
+            //compass " " [ ]                                      // defend name
+        ]
+        if (= (gamemode) 3) [ // ctf
+            compass "attack flag" [sayteam "bots attack flag"] // attack affinity
+            compass "attack base" [sayteam "bots attack base"] // attack location
+            //compass " " [ ]                                      // attack name
+            compass "defend me"   [sayteam "bots defend me"]   // defend me
+            compass "defend here" [sayteam "bots defend here"] // defend here
+            compass "defend flag" [sayteam "bots defend flag"] // defend affinity
+            compass "defend base" [sayteam "bots defend base"] // defend location
+            //compass " " [ ]                                      // defend name
+        ]
+        if (= (gamemode) 4) [ // dac
+            compass " " [ ]                                      // attack affinity
+            compass " " [ ]                                      // attack location
+            //compass " " [ ]                                      // attack name
+            compass "defend me"   [sayteam "bots defend me"]     // defend me
+            compass "defend here" [sayteam "bots defend here"]   // defend here
+            compass " " [ ]                                      // defend affinity
+            compass " " [ ]                                      // defend location
+            //compass " " [ ]                                      // defend name
+        ]
+        if (= (gamemode) 5) [ // bb
+            compass "attack ball" [sayteam "bots attack ball"] // attack affinity
+            compass "attack goal" [sayteam "bots attack goal"] // attack location
+            //compass " " [ ]                                      // attack name
+            compass "defend me"   [sayteam "bots defend me"]   // defend me
+            compass "defend here" [sayteam "bots defend here"] // defend here
+            compass " " [ ]                                    // defend affinity
+            compass "defend goal" [sayteam "bots defend goal"] // defend location
+            //compass " " [ ]                                      // defend name
+        ]
+        compass "reset" [sayteam "bots reset"]
+    ]
+]
+
 bind V [showcompass voice]
 bind X [showcompass team]
+bind B [showcompass bot]

--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -41,53 +41,50 @@ newcompass team "textures/hud/voices" [
 ]
 
 newcompass bot "textures/hud/voices" [
-    if (|| (= (gamemode) 0) (= (gamemode) 6)) [ // edit or race
-    ] [
-        compass "forget" [sayteam "bots forget"]
-        if (= (gamemode) 2) [ // dm
-            compass " " [ ]                                      // attack affinity
-            compass " " [ ]                                      // attack location
-            //compass " " [ ]                                      // attack name
-            compass "defend me"   [sayteam "bots defend me"]     // defend me
-            compass "defend here" [sayteam "bots defend here"]   // defend here
-            compass " " [ ]                                      // defend affinity
-            compass " " [ ]                                      // defend location
-            //compass " " [ ]                                      // defend name
-        ]
-        if (= (gamemode) 3) [ // ctf
-            compass "attack flag" [sayteam "bots attack flag"] // attack affinity
-            compass "attack base" [sayteam "bots attack base"] // attack location
-            //compass " " [ ]                                      // attack name
-            compass "defend me"   [sayteam "bots defend me"]   // defend me
-            compass "defend here" [sayteam "bots defend here"] // defend here
-            compass "defend flag" [sayteam "bots defend flag"] // defend affinity
-            compass "defend base" [sayteam "bots defend base"] // defend location
-            //compass " " [ ]                                      // defend name
-        ]
-        if (= (gamemode) 4) [ // dac
-            compass " " [ ]                                      // attack affinity
-            compass " " [ ]                                      // attack location
-            //compass " " [ ]                                      // attack name
-            compass "defend me"   [sayteam "bots defend me"]     // defend me
-            compass "defend here" [sayteam "bots defend here"]   // defend here
-            compass " " [ ]                                      // defend affinity
-            compass " " [ ]                                      // defend location
-            //compass " " [ ]                                      // defend name
-        ]
-        if (= (gamemode) 5) [ // bb
-            compass "attack ball" [sayteam "bots attack ball"] // attack affinity
-            compass "attack goal" [sayteam "bots attack goal"] // attack location
-            //compass " " [ ]                                      // attack name
-            compass "defend me"   [sayteam "bots defend me"]   // defend me
-            compass "defend here" [sayteam "bots defend here"] // defend here
-            compass " " [ ]                                    // defend affinity
-            compass "defend goal" [sayteam "bots defend goal"] // defend location
-            //compass " " [ ]                                      // defend name
-        ]
-        compass "reset" [sayteam "bots reset"]
+    compass "forget" [sayteam "bots forget"]
+    if (= (gamemode) 2) [ // dm
+        compass " " [ ]                                      // attack affinity
+        compass " " [ ]                                      // attack location
+        //compass " " [ ]                                      // attack name
+        compass "defend me"   [sayteam "bots defend me"]     // defend me
+        compass "defend here" [sayteam "bots defend here"]   // defend here
+        compass " " [ ]                                      // defend affinity
+        compass " " [ ]                                      // defend location
+        //compass " " [ ]                                      // defend name
     ]
+    if (= (gamemode) 3) [ // ctf
+        compass "attack flag" [sayteam "bots attack flag"] // attack affinity
+        compass "attack base" [sayteam "bots attack base"] // attack location
+        //compass " " [ ]                                      // attack name
+        compass "defend me"   [sayteam "bots defend me"]   // defend me
+        compass "defend here" [sayteam "bots defend here"] // defend here
+        compass "defend flag" [sayteam "bots defend flag"] // defend affinity
+        compass "defend base" [sayteam "bots defend base"] // defend location
+        //compass " " [ ]                                      // defend name
+    ]
+    if (= (gamemode) 4) [ // dac
+        compass " " [ ]                                      // attack affinity
+        compass " " [ ]                                      // attack location
+        //compass " " [ ]                                      // attack name
+        compass "defend me"   [sayteam "bots defend me"]     // defend me
+        compass "defend here" [sayteam "bots defend here"]   // defend here
+        compass " " [ ]                                      // defend affinity
+        compass " " [ ]                                      // defend location
+        //compass " " [ ]                                      // defend name
+    ]
+    if (= (gamemode) 5) [ // bb
+        compass "attack ball" [sayteam "bots attack ball"] // attack affinity
+        compass "attack goal" [sayteam "bots attack goal"] // attack location
+        //compass " " [ ]                                      // attack name
+        compass "defend me"   [sayteam "bots defend me"]   // defend me
+        compass "defend here" [sayteam "bots defend here"] // defend here
+        compass " " [ ]                                    // defend affinity
+        compass "defend goal" [sayteam "bots defend goal"] // defend location
+        //compass " " [ ]                                      // defend name
+    ]
+    compass "reset" [sayteam "bots reset"]
 ]
 
 bind V [showcompass voice]
 bind X [showcompass team]
-bind B [showcompass bot]
+bind B [if (&& (>= (gamemode) 2) (< (gamemode) 6)) [showcompass bot]]


### PR DESCRIPTION
Bot command quick-chat menu, opened via the B key.
Automatically disabled for demo, edit and race.
Attack and defend options appear in same places regardless of game mode.
Sends the commands to team chat (so those pesky enemies don't know what you're planning)