### PR TITLE
don't test an uninitialised var in stickyevent::process()

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3934,7 +3934,7 @@ namespace server
                 if(G(serverdebug) >= 2) srvmsgf(ci->clientnum, "sync error: sticky [%d (%d)] failed - not found", weap, id);
                 return;
             }
-            clientinfo *m = m >= 0 ? (clientinfo *)getinfo(target) : NULL;
+            clientinfo *m = target >= 0 ? (clientinfo *)getinfo(target) : NULL;
             if(target < 0 || (m && m->state.state == CS_ALIVE && !m->state.protect(gamemillis, m_protect(gamemode, mutators))))
                 sendf(-1, 1, "ri9ix", N_STICKY, ci->clientnum, target, id, norm.x, norm.y, norm.z, pos.x, pos.y, pos.z, ci->clientnum);
             else if(G(serverdebug) >= 2) srvmsgf(ci->clientnum, "sync error: sticky [%d (%d)] failed - state disallows it", weap, id);


### PR DESCRIPTION
stickyevent::process() uses the value of an uninitialised variable when
deciding whether to call getinfo().  Test the target variable passed to
getinfo() not the clientinfo variable the result is stored to.