### PR TITLE
show votes count in guitab header

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -547,7 +547,7 @@ newgui maps [
         mapsmenuiter
         guilist [ mapsmenu ]
         if (|| (getclientcount) (getvote)) [
-            guitab "votes"
+            guitab (format "%1 vote%2" $votenum (? (= 1 $votenum) "" "s"))
             guilist [ votemenu ]
         ]
     ]


### PR DESCRIPTION
show the number of suggested votes in the tab header of the votes menu (F4), so it is visible from the maps menu (F3).

based on an idea by @iceflowRE