### PR TITLE
improve display of votes count

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -493,7 +493,7 @@ votemenu = [
                 guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend
                 guilist [
                     guistrut 1
-                    guitext (format "^fc%1 ^fwvote%2" $votenum (? (!= $votenum 1) "s"))
+                    guitext (format "^fc%1 ^fwgame%2 suggested" $votenum (? (!= $votenum 1) "s"))
                     guistrut 1
                 ]
             ]
@@ -547,7 +547,9 @@ newgui maps [
         mapsmenuiter
         guilist [ mapsmenu ]
         if (|| (getclientcount) (getvote)) [
-            guitab (format "%1 vote%2" $votenum (? (= 1 $votenum) "" "s"))
+            votesum = 0
+            loop j $votenum [ votesum = (+ $votesum (getvote $j 0)) ]
+            guitab (format "%1 vote%2" $votesum (? (= 1 $votesum) "" "s"))
             guilist [ votemenu ]
         ]
     ]


### PR DESCRIPTION
I realize that with  #156, the votes count in the guitab header and in the box at the top right are the same.
So, what about showing the total of votes (i.e. the player count) in the header, 
and keeping the number of *games suggested* in the box?