### PR TITLE
genkey make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ src/redeclipse_*
 bin/x86/redeclipse_*
 bin/amd64/redeclipse_*
 bin/redeclipse_*
+src/genkey_*
+bin/x86/genkey_*
+bin/amd64/genkey_*
+bin/genkey_*
 bin/redeclipse.app/Contents/MacOS/redeclipse_universal
 src/.objs/
 *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -254,7 +254,7 @@ install-cube2font: cube2font
 	install -m 755 $< $(INSTDIR)/$<
 endif
 
-install: install-client install-server install-genkey
+install: install-client install-server
 
 $(LIBENET):
 	$(MAKE) -C enet
@@ -264,7 +264,7 @@ depend:
 	makedepend -a -o-standalone.o -Y -I. -Ishared -Iengine -Igame -DSTANDALONE $(subst -standalone.o,.cpp,$(SERVER_OBJS))
 	makedepend -a -o.h.gch -Y -I. -Ishared -Iengine -Igame $(subst .h.gch,.h,$(CLIENT_PCH))
 
-all: client server genkey
+all: client server
 
 include system-install.mk
 include dist.mk

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,6 +172,8 @@ SERVER_OBJS= \
 
 LIBENET= enet/libenet.a
 
+GENKEY_OBJS= engine/genkey.o shared/crypto-standalone.o
+
 all:
 
 default: all
@@ -184,8 +186,11 @@ clean-client:
 
 clean-server:
 	@rm -fv $(SERVER_OBJS) $(APPSERVER)$(BIN_SUFFIX)
+	
+clean-genkey:
+	@rm -fv $(GENKEY_OBJS) genkey$(BIN_SUFFIX)
 
-clean: clean-enet clean-client clean-server
+clean: clean-enet clean-client clean-server clean-genkey
 
 %.h.gch: %.h
 	$(CXX) $(CXXFLAGS) -x c++-header -o $(subst .h.gch,.tmp.h.gch,$@) $(subst .h.gch,.h,$@)
@@ -219,6 +224,11 @@ client: $(APPCLIENT)$(APPMODIFIER)$(BIN_SUFFIX)
 
 server: $(APPSERVER)$(APPMODIFIER)$(BIN_SUFFIX)
 
+genkey$(BIN_SUFFIX): $(GENKEY_OBJS)
+	$(CXX) $(CXXFLAGS) -o genkey$(BIN_SUFFIX) $(GENKEY_OBJS)
+engine/genkey.o:
+	$(CXX) $(CXXFLAGS) $(SERVER_INCLUDES) -c -o engine/genkey.o engine/genkey.cpp
+
 $(INSTDIR)/%$(BIN_SUFFIX): %$(APPMODIFIER)$(BIN_SUFFIX)
 	$(MKDIR) $(INSTDIR)
 	$(CP) $< $@
@@ -229,6 +239,8 @@ endif
 install-client: $(INSTDIR)/$(APPCLIENT)$(BIN_SUFFIX)
 
 install-server: $(INSTDIR)/$(APPSERVER)$(BIN_SUFFIX)
+
+install-genkey: $(INSTDIR)/genkey$(BIN_SUFFIX)
 
 ifeq (,$(findstring mingw,$(PLATFORM)))
 shared/cube2font.o: shared/cube2font.c
@@ -242,7 +254,7 @@ install-cube2font: cube2font
 	install -m 755 $< $(INSTDIR)/$<
 endif
 
-install: install-client install-server
+install: install-client install-server install-genkey
 
 $(LIBENET):
 	$(MAKE) -C enet
@@ -252,7 +264,7 @@ depend:
 	makedepend -a -o-standalone.o -Y -I. -Ishared -Iengine -Igame -DSTANDALONE $(subst -standalone.o,.cpp,$(SERVER_OBJS))
 	makedepend -a -o.h.gch -Y -I. -Ishared -Iengine -Igame $(subst .h.gch,.h,$(CLIENT_PCH))
 
-all: client server
+all: client server genkey
 
 include system-install.mk
 include dist.mk


### PR DESCRIPTION
Allows compilation of the genkey program (used for generating authkeys) with the makefile.
(Already in the Code::Blocks project.)