### PR TITLE
demoautoserversave variable for the server to auto save demos, closes #162

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -22,6 +22,7 @@ setdesc "demolock" "determines who may record demos;^n0 = off, 1 = player, 2 = s
 setdesc "democount" "determines the maximum amount of demo files that may be saved simultaneously on the server (deletes old demos if exceeded)" "<value>"
 setdesc "demomaxsize" "determines the maximum size of individual demo files that may be saved on the server" "<kilobytes>"
 setdesc "demoautorec" "determines if demos are automatically recorded each match" "<value>"
+setdesc "demoautosave" "determines if the server automatically saves demos to disk" "<value>"
 setdesc "mastermode" "set a specific mode to the server;^n0 = open (everybody can join), 1 = veto (vetolock determines who can force a vote), 2 = locked (only moderator or higher can spawn), 3 = private (only global privs and players with the password can join the server)" "<value>"
 setdesc "masterlock" "determines who can set mastermode;^n0 = off, 1 = player, 2 = supporter, 3 = moderator, 4 = operator, 5 = administrator, 6 = developer, 7 = founder" "<value>"
 setdesc "spawneditlock" "determines who may spawn during editing when mastermode = 2 (lock), but not make changes to the map;^n0 = off, 1 = player, 2 = supporter, 3 = moderator, 4 = operator, 5 = administrator, 6 = developer, 7 = founder" "<value>"

--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -22,7 +22,7 @@ setdesc "demolock" "determines who may record demos;^n0 = off, 1 = player, 2 = s
 setdesc "democount" "determines the maximum amount of demo files that may be saved simultaneously on the server (deletes old demos if exceeded)" "<value>"
 setdesc "demomaxsize" "determines the maximum size of individual demo files that may be saved on the server" "<kilobytes>"
 setdesc "demoautorec" "determines if demos are automatically recorded each match" "<value>"
-setdesc "demoautosave" "determines if the server automatically saves demos to disk" "<value>"
+setdesc "demoautoserversave" "determines if the server automatically saves demos to disk" "<value>"
 setdesc "mastermode" "set a specific mode to the server;^n0 = open (everybody can join), 1 = veto (vetolock determines who can force a vote), 2 = locked (only moderator or higher can spawn), 3 = private (only global privs and players with the password can join the server)" "<value>"
 setdesc "masterlock" "determines who can set mastermode;^n0 = off, 1 = player, 2 = supporter, 3 = moderator, 4 = operator, 5 = administrator, 6 = developer, 7 = founder" "<value>"
 setdesc "spawneditlock" "determines who may spawn during editing when mastermode = 2 (lock), but not make changes to the map;^n0 = off, 1 = player, 2 = supporter, 3 = moderator, 4 = operator, 5 = administrator, 6 = developer, 7 = founder" "<value>"

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -841,7 +841,7 @@ namespace server
     extern void stopdemo();
     extern void hashpassword(int cn, int sessionid, const char *pwd, char *result, int maxlen = MAXSTRLEN);
     extern bool servcmd(int nargs, const char *cmd, const char *arg);
-    extern const char *gamename(int mode, int muts, int compact = 0, int limit = 0);
+    extern const char *gamename(int mode, int muts, int compact = 0, int limit = 0, const char *separator = " ");
     extern const char *privname(int priv = PRIV_NONE, int actortype = A_PLAYER);
     extern const char *privnamex(int priv = PRIV_NONE, int actortype = A_PLAYER, bool local = false);
 #ifdef GAMESERVER

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2239,6 +2239,16 @@ namespace server
         demotmp->seek(0, SEEK_SET);
         demotmp->read(d.data, len);
         DELETEP(demotmp);
+        if(G(demoautosave))
+        {
+            string dafilepath;
+            if(*filetimeformat) formatstring(dafilepath)("demos/sv_%s.dmo", gettime(d.ctime, filetimeformat));
+            else formatstring(dafilepath)("demos/sv_%u.dmo", uint(d.ctime));
+            stream *dafile=openrawfile(dafilepath, "w");
+            dafile->write(d.data, d.len);
+            dafile->close();
+            DELETEP(dafile);
+        }
     }
 
     void enddemorecord(bool full)

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -1173,7 +1173,7 @@ namespace server
     }
     ICOMMAND(0, getversion, "i", (int *a), intret(getver(*a)));
 
-    const char *gamename(int mode, int muts, int compact, int limit)
+    const char *gamename(int mode, int muts, int compact, int limit, const char *separator)
     {
         if(!m_game(mode)) mode = G_DEATHMATCH;
         if(gametype[mode].implied) muts |= gametype[mode].implied;
@@ -1202,7 +1202,7 @@ namespace server
                     }
                 }
             }
-            defformatstring(mname)("%s%s%s", *gname ? gname : "", *gname ? " " : "", k < 3 ? gametype[mode].name : gametype[mode].sname);
+            defformatstring(mname)("%s%s%s", *gname ? gname : "", *gname ? separator : "", k < 3 ? gametype[mode].name : gametype[mode].sname);
             if(k < 3 && limit > 0 && int(strlen(mname)) >= limit)
             {
                 gname[0] = 0;
@@ -2242,8 +2242,8 @@ namespace server
         if(G(demoautosave))
         {
             string dafilepath;
-            if(*filetimeformat) formatstring(dafilepath)("demos/sv_%s.dmo", gettime(d.ctime, filetimeformat));
-            else formatstring(dafilepath)("demos/sv_%u.dmo", uint(d.ctime));
+            if(*filetimeformat) formatstring(dafilepath)("demos/sv_%s_%s-%s.dmo", gettime(d.ctime, filetimeformat), gamename(gamemode, mutators, 1, 32, "_"), smapname);
+            else formatstring(dafilepath)("demos/sv_%u_%s-%s.dmo", uint(d.ctime), gamename(gamemode, mutators, 1, 32, "_"), smapname);
             stream *dafile=openrawfile(dafilepath, "w");
             dafile->write(d.data, d.len);
             dafile->close();

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2239,7 +2239,7 @@ namespace server
         demotmp->seek(0, SEEK_SET);
         demotmp->read(d.data, len);
         DELETEP(demotmp);
-        if(G(demoautosave))
+        if(G(demoautoserversave))
         {
             string dafilepath;
             if(*filetimeformat) formatstring(dafilepath)("demos/sv_%s_%s-%s.dmo", gettime(d.ctime, filetimeformat), gamename(gamemode, mutators, 1, 32, "_"), smapname);

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -52,7 +52,7 @@ GVAR(IDF_ADMIN, demomaxsize, 1, 16, VAR_MAX);
 GVAR(IDF_ADMIN, demoautorec, 0, 1, 1); // 0 = off, 1 = automatically record demos each match
 GVAR(IDF_ADMIN, demokeep, 0, 0, 1); // 0 = off, 1 = keep demos that don't run to end of match
 GVAR(IDF_ADMIN, demoautoserversave, 0, 0, 1);
-GVAR(IDF_ADMIN, demoserverkeeptime, 0, 0, VAR_MAX); //Hours
+GVAR(IDF_ADMIN, demoserverkeeptime, 0, 0, VAR_MAX);
 
 GVAR(IDF_ADMIN, speclock, 0, PRIV_MODERATOR, PRIV_CREATOR);
 GVAR(IDF_ADMIN, teamlock, 0, PRIV_MODERATOR, PRIV_CREATOR);

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -52,6 +52,7 @@ GVAR(IDF_ADMIN, demomaxsize, 1, 16, VAR_MAX);
 GVAR(IDF_ADMIN, demoautorec, 0, 1, 1); // 0 = off, 1 = automatically record demos each match
 GVAR(IDF_ADMIN, demokeep, 0, 0, 1); // 0 = off, 1 = keep demos that don't run to end of match
 GVAR(IDF_ADMIN, demoautoserversave, 0, 0, 1);
+GVAR(IDF_ADMIN, demoserverkeeptime, 0, 0, VAR_MAX); //Hours
 
 GVAR(IDF_ADMIN, speclock, 0, PRIV_MODERATOR, PRIV_CREATOR);
 GVAR(IDF_ADMIN, teamlock, 0, PRIV_MODERATOR, PRIV_CREATOR);

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -51,7 +51,7 @@ GVAR(IDF_ADMIN, democount, 1, 10, VAR_MAX);
 GVAR(IDF_ADMIN, demomaxsize, 1, 16, VAR_MAX);
 GVAR(IDF_ADMIN, demoautorec, 0, 1, 1); // 0 = off, 1 = automatically record demos each match
 GVAR(IDF_ADMIN, demokeep, 0, 0, 1); // 0 = off, 1 = keep demos that don't run to end of match
-GVAR(IDF_ADMIN, demoautosave, 0, 0, 1);
+GVAR(IDF_ADMIN, demoautoserversave, 0, 0, 1);
 
 GVAR(IDF_ADMIN, speclock, 0, PRIV_MODERATOR, PRIV_CREATOR);
 GVAR(IDF_ADMIN, teamlock, 0, PRIV_MODERATOR, PRIV_CREATOR);

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -51,6 +51,7 @@ GVAR(IDF_ADMIN, democount, 1, 10, VAR_MAX);
 GVAR(IDF_ADMIN, demomaxsize, 1, 16, VAR_MAX);
 GVAR(IDF_ADMIN, demoautorec, 0, 1, 1); // 0 = off, 1 = automatically record demos each match
 GVAR(IDF_ADMIN, demokeep, 0, 0, 1); // 0 = off, 1 = keep demos that don't run to end of match
+GVAR(IDF_ADMIN, demoautosave, 0, 0, 1);
 
 GVAR(IDF_ADMIN, speclock, 0, PRIV_MODERATOR, PRIV_CREATOR);
 GVAR(IDF_ADMIN, teamlock, 0, PRIV_MODERATOR, PRIV_CREATOR);

--- a/src/shared/stream.cpp
+++ b/src/shared/stream.cpp
@@ -422,6 +422,11 @@ void sethomedir(const char *dir)
     fixdir(copystring(homedir, dir));
 }
 
+const char *gethomedir()
+{
+    return &homedir[0];
+}
+
 int maskpackagedirs(int flags)
 {
     int oldmask = packagedirmask;

--- a/src/shared/tools.h
+++ b/src/shared/tools.h
@@ -1421,6 +1421,7 @@ extern const char *parentdir(const char *directory);
 extern bool fileexists(const char *path, const char *mode);
 extern bool createdir(const char *path);
 extern void sethomedir(const char *dir);
+extern const char *gethomedir();
 extern void appendhomedir(const char *dir);
 extern void addpackagedir(const char *dir, int flags = 0);
 extern int maskpackagedirs(int flags);


### PR DESCRIPTION
Enable **demoautoserversave** to automatically save demos to `<serverhome>/demos`.
Limiting the space used by this is done with **demoserverkeeptime**, which (if greater than 0), will delete all auto-saved demos older than **demoserverkeeptime** hours old.

closes #162