### PR TITLE
fix the server browser for systems without gethostbyname_r()

### DIFF
--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -39,12 +39,10 @@ int resolverloop(void * data)
         while(resolverqueries.empty()) SDL_CondWait(querycond, resolvermutex);
         rt->query = resolverqueries.pop();
         rt->starttime = totalmillis;
-        SDL_UnlockMutex(resolvermutex);
 
         ENetAddress address = { ENET_HOST_ANY, ENET_PORT_ANY };
         enet_address_set_host(&address, rt->query);
 
-        SDL_LockMutex(resolvermutex);
         if(rt->query && thread == rt->thread)
         {
             resolverresult &rr = resolverresults.add();


### PR DESCRIPTION
enet_address_set_host() is only thread safe on systems with
gethostbyname_r().  Don't unlock the resolver mutex when calling
it to prevent crashes in the server browser seen on OpenBSD.