### PR TITLE
Fix bitmap iterators signedness

### DIFF
--- a/src/shared/cube2font.c
+++ b/src/shared/cube2font.c
@@ -275,7 +275,7 @@ void writetexs(const char *name, struct fontchar *chars, int numchars, int numte
         for(i = 0; i < numchars; i++)
         {
             struct fontchar *c = &chars[i];
-            int x, y;
+            uint x, y;
             if(c->tex != tex) continue;
             texchars++;
             dst = &pixels[2*((c->y + c->offy - c->color->top)*tw + c->x + c->color->left - c->offx)];


### PR DESCRIPTION
Change x & y iterator signedness to match the unsigned ints (rows and
width of the bitmap) which they are being compared with.

Fixes [-Wsign-compare] compiler warning.
---
Just to make sure this goes through some review I'm doing it as a pull request.