### PR TITLE
A hidden variable for servers.

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -462,7 +462,7 @@ extern void localconnect(bool force = true);
 extern void localdisconnect();
 
 // serverbrowser
-extern void addserver(const char *name, int port, int priority = 0, const char *desc = NULL);
+extern void addserver(const char *name, int port, int hidden = 0, int priority = 0, const char *desc = NULL);
 
 // client
 extern char *connectname;

--- a/src/game/auth.h
+++ b/src/game/auth.h
@@ -23,6 +23,8 @@
 // Team, each modification must be approved and will be done on a case-by-case
 // basis.
 
+VAR(IDF_ADMIN, hidden, 0, 0, 1);
+
 
 void hashpassword(int cn, int sessionid, const char *pwd, char *result, int maxlen)
 {
@@ -355,7 +357,7 @@ namespace auth
         else
         {
             conoutf("updating master server");
-            requestmasterf("server %d %s %d\n", serverport, *serverip ? serverip : "*", CUR_VERSION);
+            requestmasterf("server %d %s %d %d\n", serverport, *serverip ? serverip : "*", CUR_VERSION, hidden);
         }
     }
 

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -451,14 +451,14 @@ struct serverinfo
     string name;
     string map;
     string sdesc;
-    int numplayers, lastping, lastinfo, nextping, ping, resolved, port, priority;
+    int numplayers, lastping, lastinfo, nextping, ping, resolved, port, priority, hidden;
     int pings[MAXPINGS];
     vector<int> attr;
     vector<char *> players, handles;
     ENetAddress address;
 
-    serverinfo(uint ip, int port, int priority = 0)
-     : numplayers(0), resolved(ip==ENET_HOST_ANY ? UNRESOLVED : RESOLVED), port(port), priority(priority)
+    serverinfo(uint ip, int port, int hidden, int priority = 0)
+     : numplayers(0), resolved(ip==ENET_HOST_ANY ? UNRESOLVED : RESOLVED), port(port), priority(priority), hidden(hidden)
     {
         name[0] = map[0] = sdesc[0] = '\0';
         address.host = ip;


### PR DESCRIPTION
The variable is transmitted via `addserver`.
Clients will only see servers with 'hidden=1' if they enable `listhidden`.
The purpose of this is to allow servers to be modified heavily and still be listed on the master server, while giving new players the best experience.

Idea from http://forum.freegamedev.net/viewtopic.php?f=53&t=2998