### PR TITLE
No bot command compass in ffa games

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -87,4 +87,4 @@ newcompass bot "textures/hud/voices" [
 
 bind V [showcompass voice]
 bind X [showcompass team]
-bind B [if (&& (>= (gamemode) 2) (< (gamemode) 6)) [showcompass bot]]
+bind B [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]


### PR DESCRIPTION
Bot command compass menu can't be opened in ffa games. ffa is forced for edit and demo is special case, so no need to test for this.