### PR TITLE
MakeNSIS warning fix

### DIFF
--- a/src/install/win/redeclipse.nsi
+++ b/src/install/win/redeclipse.nsi
@@ -14,11 +14,11 @@
 ; General
   ;Include Modern UI
   !include "MUI2.nsh"
-  
+
+  SetCompressor lzma
   SetCompressorDictSize 96
   SetDatablockOptimize on
-  SetCompressor lzma 
-  
+
   SetDateSave off ; Installed files will show the date they were installed instead of when they were created in git
 
   ;Default installation folder


### PR DESCRIPTION
Fixes the compressor warning by specifying LZMA before the dictionary size.