### PR TITLE
Improved weapon loadout menu & weapon names

### DIFF
--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -124,11 +124,12 @@ newgui profile [
             guistrut 3
             guilist [
                 guistrut 0.75
-                guifont "emphasis" [ 
-                    guicenter [ guitext "CHOOSE YOUR WEAPONS" ]
+                guifont "emphasis" [
+                    guicenter [ guitext "Choose your weapons" ]
                 ]
                 guistrut 0.5
                 guifont "little" [
+                    guicenter [ guitext "you will spawn with these weapons" ]
                     guicenter [ guitext (format "you can carry ^fs^fc%1^fS %2" $maxcarry (? (= $maxcarry 1) "weapon" "weapons")) ]
                 ]
                 guistrut 0.5
@@ -157,7 +158,7 @@ newgui profile [
             ]
             guibar
             guistrut 2
-            guilist [ 
+            guilist [
                 guibackground
                 guicenter [
                     guistayopen [
@@ -177,7 +178,7 @@ newgui profile [
                                     guistrut 0.125
                                     guiimage [textures/question] [loadweaps @w2 0] 0.75 0 [textures/blank] [] (? (= $w3 0) 0xFFFFFF 0x808080)
                                     guistrut 0.125
-                                ] 
+                                ]
                                 loop w1 $weapidxloadout [
                                     w4 = (+ $w1 $weapidxoffset)
                                     w5 = (at $weapname $w4)
@@ -186,25 +187,30 @@ newgui profile [
                                         guistrut 0.125
                                         guiimage (? (allowedweap $w4) [textures/weapons/@w5] [textures/warning]) [loadweaps @w2 @w4] 0.75 0 [textures/blank] [] (? (= $w3 $w4) $[@[w5]colour] 0x808080)
                                         guistrut 0.125
-                                    ] 
+                                    ]
                                 ]
                             ]
                             if $al [ gdw = (+ $gdw 1) ]
                         ]
                         guistrut 1
                         guilist [
-                            guistrut 1.5 
+                            guistrut 1.5
                             guispring 1
-                            guicenter [guibutton "random" [loadweaps 0 0] [loadweaps 1 0]]
+                            guicenter [guibutton "random" [loadweaps 0 0] [loadweaps 0 1]]
                             guispring 1
                             loop w1 $weapidxloadout [
                                 w4 = (+ $w1 $weapidxoffset)
                                 w5 = (at $weapname $w4)
-                                guibutton (format "%1" $[@[w5]longname]) [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]
+                                guibutton (format "%1" $[@[w5]name]) [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]
+                                cases $guirollovername "random" [
+                                    guitooltip "You will get a random weapon each time you spawn"
+                                ] (format "%1" $[@[w5]name]) [
+                                  guitooltip (concatword "Primary: " $[@[w5]desc1] "^n" "Secondary: " $[@[w5]desc2])
+                                ]
                                 guispring 1
-                            ]    
-                        ]    
-                        guistrut 1 
+                            ]
+                        ]
+                        guistrut 1
                     ]
                 ]
             ]
@@ -216,11 +222,11 @@ newgui profile [
         guilist [
             guistrut 3
             guilist [
-                guifont "emphasis" [ 
-                    guicenter [ guitext "CHOOSE YOUR VANITIES" ]
+                guifont "emphasis" [
+                    guicenter [ guitext "Choose your vanity items" ]
                 ]
                 guistrut 0.5
-                guifont "little" [ 
+                guifont "little" [
                 guicenter [ guitext "(vanities are for decoration only" ]
                 guicenter [ guitext "and do not influence player movement" ]
                 guicenter [ guitext "or enhance abilities in any way)" ]
@@ -257,7 +263,7 @@ newgui profile [
                             ] [ guistrut 2 ]
                         ]
                     ]
-                ]   
+                ]
             ]
         ]
     ] [ profilebuttons ]

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -248,7 +248,7 @@ namespace entities
                 int sweap = m_weapon(game::gamemode, game::mutators), attr1 = w_attr(game::gamemode, game::mutators, type, attr[0], sweap);
                 if(isweap(attr1))
                 {
-                    defformatstring(str)("\fs\f[%d]%s%s%s%s\fS", W(attr1, colour), icon ? "\f(" : "", icon ? hud::itemtex(type, attr1) : W(attr1, name), icon ? ")" : "", icon ? W(attr1, longname) : "");
+                    defformatstring(str)("\fs\f[%d]%s%s%s%s\fS", W(attr1, colour), icon ? "\f(" : "", icon ? hud::itemtex(type, attr1) : W(attr1, name), icon ? ")" : "", icon ? W(attr1, name) : "");
                     addentinfo(str);
                     if(full)
                     {

--- a/src/game/weapons.h
+++ b/src/game/weapons.h
@@ -102,23 +102,49 @@ struct hitmsg { int flags, proj, target, dist; ivec dir, vel; };
 
 #include "weapdef.h"
 
-WPSVAR(0, longname,
+WPSVAR(0, name,
     "melee attack",
     "sidearm pistol",
     "energy sword",
     "semi-auto shotgun",
     "submachine gun",
-    "flame thrower",
+    "flamethrower",
     "plasma cannon",
-    "stun zapper",
-    "pulse rifle",
-    "thermite grenade",
-    "shock mine",
-    "rocket launcher"
+    "electric zapper",
+    "laser rifle",
+    "sticky grenade",
+    "stun mine",
+    "guided rocket"
 );
-WPSVAR(0, name,
-    "melee",    "pistol",   "sword",    "shotgun",  "smg",      "flamer",   "plasma",   "zapper",   "rifle",    "grenade",  "mine",     "rocket"
+
+WPSVARM(0, desc,
+    "",
+    "Long-range, low-damage bullets with a high rate of fire.",
+    "Horizontal slice, low-damage, can be swung at short intervals.",
+    "Fires a lot of pellets. Causes mass destruction at short range, useless at long range.",
+    "Rapid-fire bullets that bounce off walls.",
+    "Short-ranged flamethrower, barbecue your foes.",
+    "Fires plasma balls at a high rate with high damage, but low accuracy.",
+    "Instantly electrocutes your enemies, slowing them down drastically.",
+    "Fires a non-charged laser.",
+    "A simple explosion device, can be cooked to control detonation delay.",
+    "Explodes and discharges electricity when someone comes too close.",
+    "A fast, highly explosive rocket with a large shockwave.",
+    // begin secondary
+    "Kicks or slides.",
+    "Slower rate of fire than the primary attack, but does more damage.",
+    "Vertical slice, swung at slower intervals than the horizontal slice, powerful when used correctly.",
+    "Long-range slug, high damage, disintegrates into shavings.",
+    "Long-range projectiles that sticks to walls before exploding into fragments.",
+    "Versatile air blast to extinguish teammates or blast players off their feet.",
+    "A charged, quickly-expanding ball of plasma that quickly sucks players in, causing great damage.",
+    "A large electric discharge, can overload the victim's armor with electricity, slowing them down drastically.",
+    "Charged laser with adjustable zoom.",
+    "A simple explosion device that sticks to whatever it hits.",
+    "Emits a laser, which when tripped causes a massive electric discharge, overloading the victim's armor, stunning them.",
+    "A slower highly-explosive guided rocket."
 );
+
 WPFVARM(0, aidist, 0, FVAR_MAX,
     16.0f,      512.0f,     48.0f,      64.0f,      512.0f,     64.0f,      512.0f,     512.f,      768.0f,     384.0f,     128.0f,     1024.0f,
     16.0f,      256.0f,     48.0f,      128.0f,     128.0f,     64.0f,      64.0f,      512.f,      2048.0f,    256.0f,     128.0f,     512.0f


### PR DESCRIPTION
Moved <weapon>longname to <weapon>name.
Improved the <weapon>names.
Removed some shoutiness in profile settings (block caps).
Added clarifcation line about what the loadout is in loadout setting menu.
Added <weapon>desc[12] providing a short description of a weapon, including tooltip in the loadout menu.

some weird newline stuff that slipped in.
