### PR TITLE
fix parallaxscale menu

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -622,13 +622,14 @@
     ]
 
     newgui parallaxscale [
-        guitext "^fo/vdelta vshaderparam parallaxscale ^fr%R ^fg%G ^fb%B"
+        guitext "^fo/vdelta vshaderparam parallaxscale ^fyscale offset"
         guitext " "
-        guibutton "flat"                        "saycommand [/vdelta vshaderparam parallaxscale 0.0 0.0 0.0]"
-        guibutton "extreme"                        "saycommand [/vdelta vshaderparam parallaxscale 0.0025 0.0025 0.0025]"
-        guibutton "another dimension"               "saycommand [/vdelta vshaderparam parallaxscale 1.0 1.0 1.0]"
-        guitext " "
-        guibutton "^foRESET ^fwto default"            "saycommand [/vdelta vshaderparam parallaxscale 0.0000025 0.0000025 0.0000025]"
+        guibutton "disabled"                    "saycommand [/vdelta vshaderparam parallaxscale 0.0 0.0]"
+        guibutton "moderate"                    "saycommand [/vdelta vshaderparam parallaxscale 0.02 0.0]"
+        guibutton "strong"                      "saycommand [/vdelta vshaderparam parallaxscale 0.05 0.0]"
+        guibutton "inverted"                    "saycommand [/vdelta vshaderparam parallaxscale -0.02 0.0]"
+        guibutton "soft blob"                   "saycommand [/vdelta vshaderparam parallaxscale 0.0 -0.02]"
+        guibutton "fish eye"                    "saycommand [/vdelta vshaderparam parallaxscale 0.0 2.0]"
     ]
 
     newgui vscroll [


### PR DESCRIPTION
Avoid confusion about parallaxscale in the editing menu: R, G, B ---> scale, offset
Replace the examples to make it more clear. Still rather useless, but at least not that wrong.