### PR TITLE
cursor now shows when there is no text (#230)

### DIFF
--- a/src/engine/textedit.h
+++ b/src/engine/textedit.h
@@ -583,6 +583,14 @@ struct editor
                 if(h+height <= pixelheight)
                     draw_text(prompt, x, y+h, color>>16, (color>>8)&0xFF, color&0xFF, 0xFF, TEXT_NO_INDENT, -1, maxwidth);
             }
+            if(hit) // When hit and no text, still draw cursor.
+            {
+                int width = 0, height = 0;
+                text_bounds(" ", width, height, maxwidth, TEXT_NO_INDENT);
+                if(h+height <= pixelheight)
+                    draw_text(" ", x, y+h, color>>16, (color>>8)&0xFF, color&0xFF, 0xFF, TEXT_NO_INDENT, 0, maxwidth);
+
+            }
             return;
         }
         int starty = scrolly, sx = 0, sy = 0, ex = 0, ey = 0;


### PR DESCRIPTION
After diving into the code for 1 hour, I finally found where to draw the cursor, so it shows when there is no text in the textbox while it's focused. This is a solution for issue #230.