### PR TITLE
improve vars menu: Flag filters & hex values

### DIFF
--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -6,37 +6,24 @@ vartypes = 7
 varnotypes = 0
 varflags = 16
 varnoflags = 128
+varsmore = 0
+varflagnames = "persist readonly rewrite world complete texture client server hex admin unknown args preload gamepreload"
 
 newgui vars [
-    //  guilist [
-    //      guitext "varflags:  "
-    //      loop i 8 [ guibitfield $i varflags (<< 1 $i) ]
-    //      guitext "  varnoflags:  "
-    //      loop i 8 [ guibitfield $i varnoflags (<< 1 $i) ]
-    //  ] 
-    //  guibar
     guiheader "variables and commands"
     numvars = (getvarinfo -1 $vartypes $varnotypes $varflags $varnoflags $varsearchstr)
     if (>= $varnum $numvars) [ varnum = -1 ]
     guilist [
         guistrut 1
         guifield varsearchstrval 32 [varsearchstr = $varsearchstrval; varnum = -1; varindex = 0] -1 0 "" 0 "^fd<enter search terms>" 1
-        guistrut 1
+        guispring 1
         guilist [
             guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
             guistrut 0.15
             guilist [
-                guistrut 0.5
-                guibitfield "integer" vartypes (<< 1 0) [varnum = -1] 
-                guistrut 1
-                guibitfield "float" vartypes (<< 1 1) [varnum = -1] 
-                guistrut 1
-                guibitfield "string" vartypes (<< 1 2) [varnum = -1] 
-                guistrut 1
-                guibitfield "command" vartypes (<< 1 3) [varnum = -1] 
-                guistrut 1
-                guibitfield "alias" vartypes (<< 1 4) [varnum = -1] 
-                guistrut 0.5
+                guitext " ^fashow " 
+                guibitfield "commands  " vartypes (<< 1 3) [varnum = -1] 
+                guicheckbox "advanced filters  " varsmore
             ]
             guistrut 0.15
         ]
@@ -85,7 +72,7 @@ newgui vars [
         ]
         guistrut 1
         guilist [
-            guistrut 59 1
+            guistrut ($varsmore 39 59) 1
             if (&& (>= $varnum 0) (< $varnum $numvars) (> $numvars 0)) [
                 scurvar = (getvarinfo $varnum $vartypes $varnotypes $varflags $varnoflags $varsearchstr)
                 scurvartype = (getvartype $scurvar)
@@ -94,11 +81,20 @@ newgui vars [
                     case $scurvartype 0 [
                         guitext "^fainteger"
                         guispring 1
-                        guitext (format "^famin: ^fw%1" (getvarmin $scurvar))
-                        guispring 1
-                        guitext (format "^famax: ^fw%1" (getvarmax $scurvar))
-                        guispring 1
-                        guitext (format "^fadefault: ^fw%1" (getvardef $scurvar 1))
+                	if (& 256 (getvarflags $scurvar)) [
+                            guitext "^fahex colour"
+                            guispring 1
+                            guitext "^famin: 0x000000"
+                            guispring 1
+                            guitext "^famax: 0xFFFFFF"
+                        ] [    
+                            guitext (format "^fadefault: ^fw%1" (getvardef $scurvar 1))
+                            guitext (format "^famin: ^fw%1" (getvarmin $scurvar))
+                            guispring 1
+                            guitext (format "^famax: ^fw%1" (getvarmax $scurvar))
+                            guispring 1
+                            guitext (format "^fadefault: ^fw%1" (getvardef $scurvar 1))
+                        ]
                     ] 1 [
                         guitext "^fafloat"
                         guispring 1
@@ -124,12 +120,12 @@ newgui vars [
                     guilist [
                         guitext "^fadefault"
                         guispring 1
-                        guieditor [@[scurvar]_vardef] -58 8 4 -1 0 "" (getsvardef $scurvar 1)
+                        guieditor [@[scurvar]_vardef] (? $varsmore -43 -58) 8 4 -1 0 "" (getsvardef $scurvar 1)
                     ]
                 ]
                 guistrut 0.25
                 if (> $scurvartype 2) [
-                    guistrut 65 1
+                    guistrut (? $varsmore 50 65) 1
                     guilist [
                         guitext "^faconsole"
                         guistrut 1
@@ -148,50 +144,83 @@ newgui vars [
                         ]
                     ]
                 ] [    
-                    guistrut 65 1
-                    guilist [
-                        guitext "value"
-                        guistrut 1
-                        [@[scurvar]_varval] = $$scurvar
-                        guifield [@[scurvar]_varval] -58 [@scurvar $[@@[scurvar]_varval]] -1 0 ""
+                    guistrut (? $varsmore 50 65) 1
+                    if (& 256 (getvarflags $scurvar)) [
+                        guilist [
+                            guitext (format "^fadefault: ^fw%1" (hexcolour (getvardef $scurvar 1)))
+                            guispring 1
+                            guilist [
+                                guibackground (getvardef $scurvar) 1.0  0xffffff 1.0 1
+                                guistrut 8 1
+                                guistrut 1.25
+                            ]
+                        ]    
+                        guilist [
+                            guitext "value:"
+                            guistrut 1
+                            [@[scurvar]_varval] = (hexcolour $$scurvar)
+                            guifield [@[scurvar]_varval] 10 [@scurvar $[@@[scurvar]_varval]] -1 0 ""
+                            guispring 1
+                            guilist [
+                                guibackground $$scurvar 1.0  0xffffff 1.0 1
+                                guistrut 8 1
+                                guistrut 1.25
+                            ]
+                        ]
+                    ] [
+                        guilist [
+                            guitext "value:"
+                            guistrut 1
+                            [@[scurvar]_varval] = $$scurvar
+                            guifield [@[scurvar]_varval] (? $varsmore -43 -58) [@scurvar $[@@[scurvar]_varval]] -1 0 ""
+                        ]
                     ]
                 ]
-                if (= $scurvartype 0) [
-                    if (= 0xffffff (getvarmax $scurvar)) [
-                        guistrut 0.25
-                        guilist [
-                            guitext (format "^fahex value: ^fw%1" (hexcolour $$scurvar))
-                            guispring 1
-                            guitext "^fa preview:"
-                            guistrut 1
-                            guiimage "textures/guiskin.png" [] 1.5 0 "" [] $$scurvar
-                        ]
-                    ] 
-                ] 
                 scurusage = (getvarusage $scurvar)
                 if (stringlen $scurusage) [
                     guistrut 0.25
                     guilist [
-                        guitext "^fausage"
-                        guispring 1
-                        guitext (concat $scurvar $scurusage) "" -1 -1 1220
+                        guitext "^fausage:"
+                        guistrut 1
+                        guitext (concat $scurvar $scurusage) "" -1 -1 1000
                     ]
                 ]
                 scurdesc = (getvardesc $scurvar)
                 if (stringlen $scurdesc) [
                     guistrut 0.25
                     guilist [
-                        guitext "^fainfo"
-                        guispring 1
-                        guitext $scurdesc "" -1 -1 1220
+                        guitext "^fainfo:"
+                        guistrut 1
+                        guitext $scurdesc "" -1 -1 1000
                     ]
                 ]
             ] [
-                guistrut 65 1
+                guistrut (? $varsmore 50 65) 1
                 guifont "emphasis" [ guitext "no variable or command selected" ]
                 guifont "little" [
                     guitext "^fause the list on the left to pick a variable" point
                     guitext "^fause the search field at the top to narrow results" point
+                ]
+            ]
+        ]
+        guistrut 2
+        if ($varsmore) [
+            guilist [
+                guistrut 15 1 
+                guistrut 0.5
+                guitext "^fafilter by type"
+                guibitfield "integer" vartypes (<< 1 0) [varnum = -1] 
+                guibitfield "float"   vartypes (<< 1 1) [varnum = -1] 
+                guibitfield "string"  vartypes (<< 1 2) [varnum = -1] 
+                guibitfield "alias"   vartypes (<< 1 4) [varnum = -1] 
+                guibitfield "local"   vartypes (<< 1 5) [varnum = -1] 
+                guistrut 0.5
+                guitext "^faflags / exclude"
+                loop i (listlen $varflagnames) [
+                    guilist [
+                        guibitfield "" varflags (<< 1 $i) [varnum = -1] 
+                        guibitfield (at $varflagnames $i) varnoflags (<< 1 $i) [varnum = -1] 
+                    ]
                 ]
             ]
         ]

--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -35,7 +35,7 @@ newgui vars [
                 guistrut 0.15
                 guilist [
                     guistrut 0.5
-                    guibitfield "commands  " vartypes (<< 1 3) [varnum = -1] 
+                    guibitfield "include commands" vartypes (<< 1 3) [varnum = -1] 
                     guistrut 0.5
                 ]
                 guistrut 0.15
@@ -183,6 +183,28 @@ newgui vars [
                                 guistrut 1.25
                             ]
                         ]
+                        guistrut 0.5
+                        guilist [
+                            colr = (& (>> $$scurvar 16) 0xFF)
+                            colg = (& (>> $$scurvar 8) 0xFF)
+                            colb = (& $$scurvar 0xFF)
+                            guitext "RGB values:"
+                            guistrut 1
+                            guilist [
+                                loop i 3 [
+                                    n = [col@(at "r g b" $i)]
+                                    guilist [
+                                        guilist [
+                                            guistrut 30 1
+                                            guislider $n 0 255 [
+                                                $scurvar (+ (<< $colr 0x10) (<< $colg 0x8) $colb)
+                                            ] 0 1 (at [0xFF0000 0x00FF00 0x0000FF] $i) 1 (<< $$n (* (- 2 $i) 8))
+                                        ]
+                                        guitext (concatword "^f[" (at [0xFF0000 0x00FF00 0x0000FF] $i) "]" (at "R G B" $i))
+                                    ]
+                                ]
+                            ]
+                        ]
                     ] [ 
                         guilist [
                             guitext "value:"
@@ -190,19 +212,16 @@ newgui vars [
                             [@[scurvar]_varval] = $$scurvar
                             guifield [@[scurvar]_varval] (? $varsmore -43 -58) [@scurvar $[@@[scurvar]_varval]] -1 0 ""
                         ]
-                        //// check if the max value is 2^n -1 --> could be a bitlist
-                        //m = (getvarmax $scurvar)
-                        //if (= 0 (& $m (+ $m 1))) [
-                        //    guilist [
-                        //        guitext "bitwise:"
-                        //        guistrut 1
-                        //        loopwhile i 24 [< (<< 1 $i) $m] [
-                        //            j = 
-                        //            guibitfield  "" $scurvar (<< 1 $i)
-                        //        ]
-                        //    ]
-                        //    if (=s $guirolloveraction $scurvar) [guitooltip "toggles a bit value: 1 2 4 8 16 ..."]
-                        //]    
+                    ]    
+                    if (& (= (getvartype $scurvar) 0) (< (getvarmax $scurvar) (<< 1 20))) [
+                        guistrut 0.5
+                        guilist [
+                            guitext "bitwise value:"
+                            guistrut 1
+                            loopwhile i 20 [< (<< 1 $i) (getvarmax $scurvar)] [
+                                guibitfield  "" $scurvar (<< 1 $i)
+                            ]
+                        ]
                     ]
                 ]
                 scurusage = (getvarusage $scurvar)
@@ -236,28 +255,35 @@ newgui vars [
         if ($varsmore) [
             guilist [
                 guistrut 15 1 
-                guicenter [ guistayopen [ guibutton "^fyreset" [
-                        vartypes = 7; varflags = 16; varflags = 0; varnoflags = 128
-                ] ] ]
-                guitext "^fatypes"
+                guicenter [guitext "^fatypes"]
                 loop i (listlen $vartypenames) [
                     guilist [
                         guibitfield "" vartypes (<< 1 $i) [varnotypes = 0; varnum = -1] 
-                        guibitfield (at $vartypenames $i) varnotypes (<< 1 $i) [vartypes = 0; varnum = -1] 
+                        guispring 1
+                        guitext (at $vartypenames $i)
+                        guispring 1
+                        guibitfield "" varnotypes (<< 1 $i) [vartypes = 0; varnum = -1] 
                     ]
-                    if (=s $guirolloveraction vartypes) [guitooltip "only vars of this type"]
+                    if (=s $guirolloveraction vartypes) [guitooltip "only vars of these types"]
                     if (=s $guirolloveraction varnotypes) [guitooltip "only vars of other types"]
                 ]
-                guistrut 0.5
-                guitext "^faflags"
+                guistrut 0.3
+                guicenter [guitext "^faflags"]
                 loop i (listlen $varflagnames) [
                     guilist [
                         guibitfield "" varflags (<< 1 $i) [ varnum = -1] 
-                        guibitfield (at $varflagnames $i) varnoflags (<< 1 $i) [ varnum = -1] 
+                        guispring 1
+                        guitext (at $varflagnames $i)
+                        guispring 1
+                        guibitfield "" varnoflags (<< 1 $i) [ varnum = -1] 
                     ]
-                    if (=s $guirolloveraction varflags) [guitooltip "only vars with this flag"]
-                    if (=s $guirolloveraction varnoflags) [guitooltip "only vars without this flag"]
+                    if (=s $guirolloveraction varflags) [guitooltip "only vars with these flags"]
+                    if (=s $guirolloveraction varnoflags) [guitooltip "only vars without these flags"]
                 ]
+                guistrut 0.3
+                guicenter [ guistayopen [ guibutton "^fyreset" [
+                        vartypes = 7; varflags = 16; varnotypes = 0; varnoflags = 128; varnum = -1
+                ] ] ]
             ]
         ]
     ]

--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -255,30 +255,35 @@ newgui vars [
         if ($varsmore) [
             guilist [
                 guistrut 15 1 
-                guicenter [guitext "^fatypes"]
+                guicenter [ guitext "^fatypes" ]
                 loop i (listlen $vartypenames) [
                     guilist [
                         guibitfield "" vartypes (<< 1 $i) [varnotypes = 0; varnum = -1] 
                         guispring 1
                         guitext (at $vartypenames $i)
                         guispring 1
-                        guibitfield "" varnotypes (<< 1 $i) [vartypes = 0; varnum = -1] 
-                    ]
-                    if (=s $guirolloveraction vartypes) [guitooltip "only vars of these types"]
-                    if (=s $guirolloveraction varnotypes) [guitooltip "only vars of other types"]
+                        //guibitfield "" varnotypes (<< 1 $i) [vartypes = 0; varnum = -1] 
+                        guistayopen [ guiimage "textures/warning" [
+                            varnotypes = (^ $varnotypes (<< 1 @i)) ; varnum = -1; vartypes = 0
+                        ] 0.5 0 "" [] (? (& $varnotypes (<< 1 $i)) 0xff0000 0x999999)]
+                    ] 
+                    if (=s $guirolloveraction vartypes) [guitooltip "only these types"]
                 ]
                 guistrut 0.3
-                guicenter [guitext "^faflags"]
+                guicenter [ guitext "^faflags" ]
                 loop i (listlen $varflagnames) [
                     guilist [
                         guibitfield "" varflags (<< 1 $i) [ varnum = -1] 
                         guispring 1
                         guitext (at $varflagnames $i)
                         guispring 1
-                        guibitfield "" varnoflags (<< 1 $i) [ varnum = -1] 
+                        //guibitfield "" varnoflags (<< 1 $i) [ varnum = -1] 
+                        guistayopen [ guiimage "textures/warning" [
+                            varnoflags = (^ $varnoflags (<< 1 @i)) ; varnum = -1
+                        ] 0.5 0 "" [] (? (& $varnoflags (<< 1 $i)) 0xff0000 0x999999)]
                     ]
-                    if (=s $guirolloveraction varflags) [guitooltip "only vars with these flags"]
-                    if (=s $guirolloveraction varnoflags) [guitooltip "only vars without these flags"]
+                    if (=s $guirolloveraction varflags) [guitooltip "any of these flags"]
+                    if (=s $guirollovername textures/warning) [guitooltip "none of these"]
                 ]
                 guistrut 0.3
                 guicenter [ guistayopen [ guibutton "^fyreset" [

--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -89,6 +89,7 @@ newgui vars [
                             guitext "^famax: 0xFFFFFF"
                         ] [    
                             guitext (format "^fadefault: ^fw%1" (getvardef $scurvar 1))
+                            guispring 1
                             guitext (format "^famin: ^fw%1" (getvarmin $scurvar))
                             guispring 1
                             guitext (format "^famax: ^fw%1" (getvarmax $scurvar))

--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -7,6 +7,7 @@ varnotypes = 0
 varflags = 16
 varnoflags = 128
 varsmore = 0
+vartypenames = "integer float string command alias local"
 varflagnames = "persist readonly rewrite world complete texture client server hex admin unknown args preload gamepreload"
 
 newgui vars [
@@ -16,18 +17,7 @@ newgui vars [
     guilist [
         guistrut 1
         guifield varsearchstrval 32 [varsearchstr = $varsearchstrval; varnum = -1; varindex = 0] -1 0 "" 0 "^fd<enter search terms>" 1
-        guispring 1
-        guilist [
-            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
-            guistrut 0.15
-            guilist [
-                guitext " ^fashow " 
-                guibitfield "commands  " vartypes (<< 1 3) [varnum = -1] 
-                guicheckbox "advanced filters  " varsmore
-            ]
-            guistrut 0.15
-        ]
-        guispring 1
+        guistrut 3
         guilist [
             guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
             guistrut 0.15
@@ -35,6 +25,31 @@ newgui vars [
                 guistrut 1
                 guitext (format "^fg%1 ^fa%2 found" $numvars (? (= $numvars 1) "match" "matches"))
                 guistrut 1
+            ]
+            guistrut 0.15
+        ]
+        guispring 1
+        if (= $varsmore 0) [
+            guilist [
+                guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
+                guistrut 0.15
+                guilist [
+                    guistrut 0.5
+                    guibitfield "commands  " vartypes (<< 1 3) [varnum = -1] 
+                    guistrut 0.5
+                ]
+                guistrut 0.15
+            ]
+        ]
+        guispring 1
+        guilist [
+            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
+            guistrut 0.15
+            guilist [
+                //guitext " ^fashow " 
+                guistrut 0.5
+                guicheckbox " advanced filters" varsmore
+                guistrut 0.5
             ]
             guistrut 0.15
         ]
@@ -168,13 +183,26 @@ newgui vars [
                                 guistrut 1.25
                             ]
                         ]
-                    ] [
+                    ] [ 
                         guilist [
                             guitext "value:"
                             guistrut 1
                             [@[scurvar]_varval] = $$scurvar
                             guifield [@[scurvar]_varval] (? $varsmore -43 -58) [@scurvar $[@@[scurvar]_varval]] -1 0 ""
                         ]
+                        //// check if the max value is 2^n -1 --> could be a bitlist
+                        //m = (getvarmax $scurvar)
+                        //if (= 0 (& $m (+ $m 1))) [
+                        //    guilist [
+                        //        guitext "bitwise:"
+                        //        guistrut 1
+                        //        loopwhile i 24 [< (<< 1 $i) $m] [
+                        //            j = 
+                        //            guibitfield  "" $scurvar (<< 1 $i)
+                        //        ]
+                        //    ]
+                        //    if (=s $guirolloveraction $scurvar) [guitooltip "toggles a bit value: 1 2 4 8 16 ..."]
+                        //]    
                     ]
                 ]
                 scurusage = (getvarusage $scurvar)
@@ -208,20 +236,27 @@ newgui vars [
         if ($varsmore) [
             guilist [
                 guistrut 15 1 
+                guicenter [ guistayopen [ guibutton "^fyreset" [
+                        vartypes = 7; varflags = 16; varflags = 0; varnoflags = 128
+                ] ] ]
+                guitext "^fatypes"
+                loop i (listlen $vartypenames) [
+                    guilist [
+                        guibitfield "" vartypes (<< 1 $i) [varnotypes = 0; varnum = -1] 
+                        guibitfield (at $vartypenames $i) varnotypes (<< 1 $i) [vartypes = 0; varnum = -1] 
+                    ]
+                    if (=s $guirolloveraction vartypes) [guitooltip "only vars of this type"]
+                    if (=s $guirolloveraction varnotypes) [guitooltip "only vars of other types"]
+                ]
                 guistrut 0.5
-                guitext "^fafilter by type"
-                guibitfield "integer" vartypes (<< 1 0) [varnum = -1] 
-                guibitfield "float"   vartypes (<< 1 1) [varnum = -1] 
-                guibitfield "string"  vartypes (<< 1 2) [varnum = -1] 
-                guibitfield "alias"   vartypes (<< 1 4) [varnum = -1] 
-                guibitfield "local"   vartypes (<< 1 5) [varnum = -1] 
-                guistrut 0.5
-                guitext "^faflags / exclude"
+                guitext "^faflags"
                 loop i (listlen $varflagnames) [
                     guilist [
-                        guibitfield "" varflags (<< 1 $i) [varnum = -1] 
-                        guibitfield (at $varflagnames $i) varnoflags (<< 1 $i) [varnum = -1] 
+                        guibitfield "" varflags (<< 1 $i) [ varnum = -1] 
+                        guibitfield (at $varflagnames $i) varnoflags (<< 1 $i) [ varnum = -1] 
                     ]
+                    if (=s $guirolloveraction varflags) [guitooltip "only vars with this flag"]
+                    if (=s $guirolloveraction varnoflags) [guitooltip "only vars without this flag"]
                 ]
             ]
         ]


### PR DESCRIPTION
add proper bitfields for filtering or excluding variable flags
per default, only show the bitfield for including commands
all other bitfields go in an advanced filter panel, enabled via a checkbox
check hex colours via their flag, show the default and value as such
nicer colour preview, also for default colours