### PR TITLE
Fix usage of len arg in engine/server.cpp:filterstring.

### DIFF
--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -295,7 +295,7 @@ bool filterstring(char *dst, const char *src, bool newline, bool colour, bool wh
 {
     bool filtered = false;
     size_t n = 0;
-    for(int c = uchar(*src); c && n < len; c = uchar(*++src))
+    for(int c = uchar(*src); c && n < len+1; c = uchar(*++src))
     {
         if(newline && (c=='\n' || c=='\r')) c = ' ';
         if(c=='\f')
@@ -326,7 +326,7 @@ bool filterstring(char *dst, const char *src, bool newline, bool colour, bool wh
         else filtered = true;
     }
     if(whitespace && wsstrip && n) while(iscubespace(dst[n-1])) dst[--n] = 0;
-    dst[n < len ? n : len-1] = 0;
+    dst[n] = 0;
     return filtered;
 }
 bool filterbigstring(char *dst, const char *src, bool newline, bool colour, bool whitespace, bool wsstrip, size_t len)


### PR DESCRIPTION
Fixes voice overs #241. The problem was with `filter` command used in `config/voice.cfg`. The command stripped last character of a string. It did so because `engine/server.cpp:filterstring` processed one character less than the given length.