### PR TITLE
improve bind lists in the controls menu

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1165,9 +1165,8 @@ newgui options_controls [
     guilist [
         guilist [ guistrut 28 ]
         guilist [
-            guitext ( format "set basic keyboard controls from this menu. for more advanced functions, use the /bind command (%1)" (dobindsearch "saycommand /") )
-            guistrut 0.5
-            guibutton "^frrestore default controls" [showgui resetcontrols]
+            //guitext ( format "set basic keyboard controls from this menu. for more advanced functions, use the /bind command (%1)" (dobindsearch "saycommand /") )
+            //guistrut 0.5
             guistrut 0.5
             guitext "click an action then press the desired keys you wish to bind (press ESC when finished):"
             guistrut 1
@@ -1175,7 +1174,9 @@ newgui options_controls [
                 guitext "state:"
                 guistrut 1
                 loop i 4 [ guiradio (at $bindtypes $i) curbindtype $i; guistrut 1 ]
-                guicheckbox "not only state-specific binds" curbindshow
+                //guicheckbox "not only state-specific binds" curbindshow
+                guispring 1
+                guibutton "^frrestore default controls" [showgui resetcontrols]
             ]
             guistrut 1
             curbindsign = (at $bindcalls $curbindtype)
@@ -1212,6 +1213,54 @@ newgui options_controls [
             guislider yawsensitivity 1 100
             guislider pitchsensitivity 1 100
         ]
+    ]
+
+    guitab "advanced"
+    guistrut 1
+    guicenter [guitext "click an icon to view and edit the corresponding key bind via the console (cancel with Esc)" "textures/menu"]
+    guistrut 1
+    // keys as listed in config/keyref.cfg with some different ordering
+    guilistsplit curkey 5 [
+        A B C D E F G H I J K L M N O P Q R S T U V W X Y Z SPACE BACKSPACE 
+        0 1 2 3 4 5 6 7 8 9
+        F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 F12 F13 F14 F15
+        TAB RETURN ESCAPE
+        MOUSE1 MOUSE2 MOUSE3 MOUSE4 MOUSE5
+        UP DOWN RIGHT LEFT INSERT DELETE HOME END PAGEUP PAGEDOWN
+        KP0 KP1 KP2 KP3 KP4 KP5 KP6 KP7 KP8 KP9
+        KP_PERIOD KP_DIVIDE KP_MULTIPLY KP_MINUS KP_PLUS KP_ENTER KP_EQUALS
+        CLEAR PAUSE EXCLAIM QUOTEDBL HASH DOLLAR AMPERSAND QUOTE
+        LEFTPAREN RIGHTPAREN ASTERISK PLUS COMMA MINUS PERIOD SLASH
+        COLON SEMICOLON LESS EQUALS GREATER QUESTION AT LEFTBRACKET BACKSLASH RIGHTBRACKET CARET UNDERSCORE BACKQUOTE
+        NUMLOCK CAPSLOCK SCROLLOCK
+        RSHIFT LSHIFT RCTRL LCTRL RALT LALT RMETA LMETA LSUPER RSUPER
+        MODE COMPOSE HELP PRINT SYSREQ BREAK MENU POWER EURO UNDO
+        ] [
+        guilist [ 
+            guistayopen [
+                curbindacts = (getbind $curkey)
+                guiimage "textures/player"    [saycommand /bind @curkey "["@curbindacts"]"] 0.5 0 [] "" (? (stringlen $curbindacts) 0x66ff66 0x666666)
+                guiimage "textures/editing"   [saycommand /editbind @curkey "["(geteditbind @curkey)"]"] 0.5 0 [] "" (? (!=s (geteditbind $curkey) $curbindacts) 0xffff00 0x666666)
+                guiimage "textures/spectator" [saycommand /specbind @curkey "["(getspecbind @curkey)"]"] 0.5 0 [] "" (? (!=s (getspecbind $curkey) $curbindacts) 0x00ffff 0x666666)
+                guiimage "textures/waiting"   [saycommand /waitbind @curkey "["(getwaitbind @curkey)"]"] 0.5 0 [] "" (? (!=s (getwaitbind $curkey) $curbindacts) 0xffaa00 0x666666)
+                guitext $curkey
+                guistrut 3
+            ]
+        ]
+    ]
+    guistrut 1
+    guilist [
+        guispring 1
+        guitext "default bind" "textures/player" -1 0x66ff66
+        guispring 1
+        guitext "edit bind" "textures/editing" -1 0xffff00
+        guispring 1
+        guitext "spectator bind" "textures/spectator" -1 0x00ffff
+        guispring 1
+        guitext "wait bind" "textures/waiting" -1 0xffaa00
+        guispring 1
+        guitext "gray icons: not in use" "" 0x666666
+        guispring 1
     ]
 ] [
     if (= $guipasses 0) [ curbindtype = 0 ]

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1049,63 +1049,95 @@ bindtypes = [ default spectator editing waiting ]
 bindcalls = [ "" spec edit wait ]
 
 bindactions = [
-    forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
-    "primary" "secondary" "reload" "use" "jump" "walk" "crouch" "special" "drop" "affinity"
+    forward backward left right 
+    "primary" "secondary" "reload" "jump" "crouch" "special" "universaldelta 1" "universaldelta -1" 
     "weapon 1" "weapon 2" "weapon 3" "weapon 4" "weapon 5" "weapon 6" "weapon 7" "weapon 8" "weapon 9" "weapon 10"
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
-    "showcompass voice" "showcompass team" [if (&& (>= (gamemode) 2) (< (gamemode) 6)) [showcompass bot]]
+    walk use drop affinity
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
+    "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
+    "spectator 1" addbot delbot   
 ]
 bindtitles = [
-    forward backward left right "scroll up" "scroll down" "enter spectator" "exit spectator"
-    "primary" "secondary" "reload" "use" "jump" "walk" "crouch" "parkour/kick" "drop" "flag/bomb"
+    forward backward left right 
+    "primary" "secondary" "reload" "jump" "crouch" "parkour/kick" "next weapon" "previous weapon" 
     "weap slot 1" "weap slot 2" "weap slot 3" "weap slot 4" "weap slot 5" "weap slot 6" "weap slot 7" "weap slot 8" "weap slot 9" "weap slot 10"
-    "cmd input" "all chat" "team chat" "toggle console" "toggle editing" "toggle thirdperson" "screenshot"
-    "add bot" "delete bot" "maps menu" "maps voting" "claim privileges" "loadout menu" "team menu"
+    walk "use / pick up" "drop weapon" "throw flag/bomb"
+    "cmd input" "all chat" "team chat" 
     "voice compass" "team compass" "bot compass"
+    "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
+    "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
+    "enter spectator" "add bot" "delete bot" 
 ]
 
 specbindactions = [
-    forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
-    "showcompass voice" "showcompass team" [if (&& (>= (gamemode) 2) (< (gamemode) 6)) [showcompass bot]]
+    forward backward left right "universaldelta 1" "universaldelta -1" 
+    specmodeswitch [if (! $isonline) [sv_gamespeed 10000; onrelease [sv_gamespeed 100]]] "spectator 0"
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
+    "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
+    "spectator 1" addbot delbot   
 ]
 specbindtitles = [
-    forward backward left right "scroll up" "scroll down" "enter spectator" "exit spectator"
-    "cmd input" "all chat" "team chat" "toggle console" "toggle editing" "toggle thirdperson" "screenshot"
-    "add bot" "delete bot" "maps menu" "maps voting" "claim privileges" "loadout menu" "team menu"
+    forward backward left right "watch next player" "watch previous player" 
+    "toggle TV mode" "fast forward (offline)" "exit spectator"
+    "cmd input" "all chat" "team chat" 
     "voice compass" "team compass" "bot compass"
+    "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
+    "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
+    "enter spectator" "add bot" "delete bot" 
 ]
 
 waitbindactions = [
-    forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle thirdpersonswitch screenshot
-    addbot delbot "showgui maps 1" "showgui maps 2" "setpriv 1" "showgui profile 2" "showgui team"
-    "showcompass voice" "showcompass team" [if (&& (>= (gamemode) 2) (< (gamemode) 6)) [showcompass bot]]
+    forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1"
+    waitmodeswitch
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
+    "spectator 1" addbot delbot   
+    "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
 ]
 waitbindtitles = [
-    forward backward left right "scroll up" "scroll down" "enter spectator" "exit spectator"
-    "cmd input" "all chat" "team chat" "toggle console" "toggle editing" "toggle thirdperson" "screenshot"
-    "add bot" "delete bot" "maps menu" "maps voting" "claim privileges" "loadout menu" "team menu"
-    "voice compass" "team compass" "bot compass"
+    forward backward left right "scroll up" "scroll down" "enter spectator" 
+    "switch wait TV mode"
+    "cmd input" "all chat" "team chat" 
+    "voice compass" "team compass" "bot compass" 
+    "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
+    "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
+    "enter spectator" "add bot" "delete bot" 
 ]
 
 editbindactions = [
-    forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1" "spectator 0"
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" toggleconsole edittoggle screenshot
-    "showtexgui" "showgui editing" "remip" "fullbright 0; patchlight" "fullbright 0; calclight -1" "fullbright 0; calclight 1"
-    savemap "changeoutline 1"
+    "showtexgui" edittoggle "showgui edit" "remip" "fullbright 0; patchlight" "fullbright 0; calclight -1" "fullbright 0; calclight 1" savemap "changeoutline 1"
+    [if $blendpaintmode paintblendmap editdrag] [if $blendpaintmode rotateblendbrush editextend] selcorners  "universaldelta 1" "universaldelta -1" 
+    cancelsel editdel editcopy editpaste editcut editflip "hmapedit (! $hmapedit); blendpaintmode 0" 
+    gettex entlink selentedit "entselect insel"
+    "undo; passthroughsel 0" redo getmap sendmap 
+    "domodifier 1" "domodifier 2" "domodifier 3" "domodifier 4" "domodifier 6" "domodifier 9" "domodifier 10; onrelease entautoview"
+    togglegrid // 
+    [fullbright (= $fullbright 0); if (= $fullbright 0) [echo fullbright OFF] [ echo fullbright ON]]
+    [showmat (= $showmat 0); if (= $showmat 0) [echo showmat OFF] [ echo showmat ON]]
+    [outline (= $outline 0); if (= $outline 0) [echo outline OFF] [ echo outline ON]]
+    [allfaces (= $allfaces 0); if (= $allfaces 0) [echo allfaces OFF] [ echo allfaces ON]]
+    [hmapedit 0;
+    blendpaintmode (? (= $blendpaintmode (getvarmax blendpaintmode)) 0 (+ $blendpaintmode 1))
+    echo (concatword "^fgblend mode:^fw " (at $paintmodes $blendpaintmode) " (^fc" $blendpaintmode "^fw)")]
 ]
 editbindtitles = [
-    forward backward left right "scroll up" "scroll down" "enter spectator" "exit spectator"
-    "cmd input" "all chat" "team chat" "toggle console" "toggle editing" "screenshot"
-    "texture menu" "editing menu" "remip" "patch lights" "quick calclight" "full calclight"
-    "save map" "change outline"
+    "texture menu"  "toggle editing" "editing menu" "remip" "patch lights" "quick calclight" "full calclight" "save map" "change outline" 
+    "select faces" "extend selection" "select corners" "pull cubes" "push cubes"
+    "deselect all" "delete selection" "copy selection" "paste" "cut/paste on release" "flip geometry" "toggle heightmap"
+    "grab texture" "link entities" "edit selected ent" "pick ents in selection"
+    undo redo "get map from server" "send map to server" 
+    "change grid size" "push/pull cube face" "push/pull cube corner" "rotate" "cycle textures" "cycle brush type" "view selected ents" 
+    "cycle paste grid"  "toggle full bright" "toggle materials" "toggle outline" "toggle all faces" 
+    "toggle blendmap mode"
 ]
 
 curbindtype = 0
-curbindshow = 0
+curbindshow = 1
 
 newgui resetcontrols [
     guiheader "reset controls"
@@ -1143,7 +1175,7 @@ newgui options_controls [
                 guitext "state:"
                 guistrut 1
                 loop i 4 [ guiradio (at $bindtypes $i) curbindtype $i; guistrut 1 ]
-                guicheckbox "show default bind if not found" curbindshow
+                guicheckbox "not only state-specific binds" curbindshow
             ]
             guistrut 1
             curbindsign = (at $bindcalls $curbindtype)

--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -1162,7 +1162,7 @@ newgui resetcontrols [
 
 newgui options_controls [
     guiheader  "keys"
-    guilist [
+    guicenter [
         guilist [ guistrut 28 ]
         guilist [
             //guitext ( format "set basic keyboard controls from this menu. for more advanced functions, use the /bind command (%1)" (dobindsearch "saycommand /") )
@@ -1199,18 +1199,25 @@ newgui options_controls [
     ]
 
     guitab  "mouse"
-    guilist [
+    guicenter [
         guilist [
+            guistrut 3
             guitext "mouse overall sensitivity"
+            guistrut 1
             guitext "mouse yaw sensitivity"
+            guistrut 1
             guitext "mouse pitch sensitivity"
             guistrut 1
             guicheckbox "invert y-axis" mouseinvert
         ]
+        guistrut 3
         guilist [
+            guistrut 5
             guistrut 50 1
             guislider sensitivity 1 100
+            guistrut 1
             guislider yawsensitivity 1 100
+            guistrut 1
             guislider pitchsensitivity 1 100
         ]
     ]
@@ -1253,7 +1260,7 @@ newgui options_controls [
         guispring 1
         guitext "default bind" "textures/player" -1 0x66ff66
         guispring 1
-        guitext "edit bind" "textures/editing" -1 0xffff00
+        guitext "editing bind" "textures/editing" -1 0xffff00
         guispring 1
         guitext "spectator bind" "textures/spectator" -1 0x00ffff
         guispring 1


### PR DESCRIPTION
list all relevant editing binds in the controls menu (options), so the editing menu can be overhauled later based on this.
make sure all controls are arranged nicely, e.g. ordering of F1-F12 default binds, grouping of chat, movement, weapons etc.
fix a few broken control lookups, e.g. bot compass
add a few more missing ones, e.g. help menu, server menu, waitmodeswitch ...
add fast forward for offline specators (we could put that in setup.cfg as well)
change checkbox label and default (seemed confusing)