### PR TITLE
fixed "go go go!" team compass bug - added 1 parameter

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -17,7 +17,7 @@ newcompass menus "textures/menu" [
 ]
 
 saycompass = [ compass $arg1 [say (format "%1%2 %3" (getsaycolour) @arg1)]]
-teamcompass = [ compass $arg1 [sayteam (format "%1%2 %3" (getsaycolour) @arg1)]]
+teamcompass = [ compass $arg1 [sayteam (format "%1%2 %3 %4" (getsaycolour) @arg1)]]
 
 newcompass voice "textures/hud/voices" [
     saycompass "argh!" 


### PR DESCRIPTION
I actually got this! This is my first time using `git bisect`. So right now when you go `x` then `6`, instead
of `go go go` I see only `go go`. The first bad commit is the one that fixes #236 - 225719a127d95b398eef0f1aa0e7856b8a92b8b8. Here is the
output of `git bisect`, just to show off:
________________
redeclipse-git$ git bisect good
225719a127d95b398eef0f1aa0e7856b8a92b8b8 is the first bad commit
commit 225719a127d95b398eef0f1aa0e7856b8a92b8b8
Author: Quinton Reeves <qreeves@gmail.com>
Date:   Mon Jul 6 19:24:34 2015 +1000

    fixed #236

:040000 040000 e25a6e00aa00ba7f292594abdc385ef9be299eed d5cc7e7273a51094674b4a54d048ee335c18fea9 M	config
_______________
@bonifarz tipped me that there should be one more parameter to the `sayteam`
line, so here it is.