### PR TITLE
clean up compass with saytextcolour

### DIFF
--- a/config/compass.cfg
+++ b/config/compass.cfg
@@ -16,8 +16,8 @@ newcompass menus "textures/menu" [
     compass "options" [showgui options]
 ]
 
-saycompass = [ compass $arg1 [say (format "%1%2 %3" (getsaycolour) @arg1)]]
-teamcompass = [ compass $arg1 [sayteam (format "%1%2 %3 %4" (getsaycolour) @arg1)]]
+saycompass = [ compass $arg1 [say (format "%1%2" (getsaycolour) [@@arg1])]]
+teamcompass = [ compass $arg1 [sayteam (format "%1%2" (getsaycolour) [@@arg1])]]
 
 newcompass voice "textures/hud/voices" [
     saycompass "argh!" 


### PR DESCRIPTION
the fix #270 works fine, but here is a clean solution, which will be useful for longer chat presets, if that will ever be needed.