### PR TITLE
fix "bitwise" in vars menu

### DIFF
--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -218,7 +218,7 @@ newgui vars [
                         guilist [
                             guitext "bitwise value:"
                             guistrut 1
-                            loopwhile i 20 [< (<< 1 $i) (getvarmax $scurvar)] [
+                            loopwhile i 20 [<= (<< 1 $i) (getvarmax $scurvar)] [
                                 guibitfield  "" $scurvar (<< 1 $i)
                             ]
                         ]


### PR DESCRIPTION
Tiny fix, so vars with a maxval of 1 get their checkbox.
Questions left to address: 
* Should the ordering of the "bitwise" checkboxes be reverse?
* Should we display them only if maxval+1 is a power of 2?