### PR TITLE
Fix engine/shader.cpp:getshaderparamname for gcc-5.1.0

### DIFF
--- a/src/engine/shader.cpp
+++ b/src/engine/shader.cpp
@@ -1177,7 +1177,7 @@ const char *getshaderparamname(const char *name, bool insert)
 {
     const char *exists = shaderparamnames.find(name, NULL);
     if(exists || !insert) return exists;
-    return shaderparamnames.add(newstring(name));
+    return shaderparamnames.add<const char *>(newstring(name));
 }
 
 void addslotparam(const char *name, float x, float y, float z, float w, int palette = 0, int palindex = 0)


### PR DESCRIPTION
New `hashset` template causes error in gcc-5.1.0. When `shaderparamnames.add(newstring(name))` is called, `shaderparamnames.add<char *>` is instantiated. It causes creation of temporary [here](https://github.com/red-eclipse/base/blob/master/src/shared/tools.h#L1048) on `H::getkey(elem)` call, since `H::getkey` is instantiated with `const char * const&`  argument (because of [this](https://github.com/red-eclipse/base/blob/master/src/engine/shader.cpp#L1174])). The temporary becomes obsolete immediately after `H::getkey` returns, but `H::getkey` returns reference to that temporary, thus `const K &key` is uninitialized and causes segfault inside `hthash` function. Only appears with optimizations enabled. Not sure why it doesn't affect other environments, maybe because it's undefined behaviour to return reference to local object.