### PR TITLE
fixes for editing menu overhaul

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -30,12 +30,13 @@
     // main edit menu bound to F3
     newgui edit [ guistayopen [
         guifont emphasis [
-            guicenter [guieditbutton2 [map, waypoints, routes] [showgui mapinfo]]
+            guicenter [guieditbutton2 [toggle edit mode] [edittoggle]]
+            guicenter [guieditbutton2 [map, waypoints and routes] [showgui mapinfo]]
             guicenter [guieditbutton2 [editing options] [showgui editoptions]]
-            guicenter [guieditbutton2 [geometry menu] [showgui geometry]]
+            guicenter [guieditbutton2 [geometry and prefabs] [showgui geometry]]
             guicenter [guieditbutton2 [world variables and lighting] [showgui world]]
             //guicenter [guieditbutton2 [texture list] [showtexgui]]
-            // this does not work when any gui is drawn! so here is an ugly work around:
+            // actually, the texgui only shows when no other gui is open, so:
             guicenter [ guilist [ guibody [
                 guibutton "texture list"
                 guistrut 1
@@ -43,10 +44,9 @@
                 guibutton (dobindsearch showtexgui edit)
             ] [cleargui ; showtexgui ] [saycommand /showtexgui] [guitooltip showtexgui]] ]    
             guicenter [guieditbutton2 [texture variations] [showgui textures]]
-            guicenter [guieditbutton2 [entity menu] [showgui ents]]
-            guicenter [guieditbutton2 [materials menu] [showgui materials]]
+            guicenter [guieditbutton2 [find and edit entities] [showgui ents]]
             guibar
-            guicenter [guieditbutton2 [same as quick compass] [showcompass editing]]
+            guicenter [guieditbutton2 [same menu as compass] [showcompass editing]]
             guicenter [guibutton "configure key binds" [sleep 50 [curbindtype = 2]; showgui options_controls]]
         ]
     ] ]
@@ -54,14 +54,14 @@
 
     // this one could go to config/compass.cfg, but it is convenient to have it here for comparison
     newcompass editing $editingtex [
-        compass "map, waypoints, ^fcr^fwoutes" R [showgui mapinfo]
+        compass "^fcQ^fwuit editing" Q [edittoggle]
+        compass "map, waypoints and ^fcr^fwoutes" R [showgui mapinfo]
         compass "e^fcd^fwiting options" D [showgui editoptions]
-        compass "^fcg^fweometry menu" G [showgui geometry]
+        compass "^fcg^fweometry and prefabs" G [showgui geometry]
         compass "^fcw^fworld and lighting" W [showgui world]
         compass "texture ^fcv^fwariations" V [showgui textures]
         compass "^fct^fwexture list" T [showtexgui]
         compass "^fcf^fwind and edit entities" F [showgui ents]
-        compass "m^fca^fwterials" A [showgui materials]
         compass "^fce^fwscape" E [cleargui 1]
     ]
 
@@ -131,7 +131,6 @@
                 ]
                 guibutton "edit the config file" [notepad @mapname.cfg] []
                 guibutton "reset the texture list" [showgui texreset] [] $warningtex
-                guibutton "start a new map" [showgui newmapgui ] []  $editingtex
             ]
         ]
 
@@ -324,7 +323,9 @@
     ] ]
 
     newgui world [ guistayopen [
-        guistatus "some buttons have tooltips and alt-actions for console commands"
+        guistatus "this menu will be expanded with more options"
+        guitext "world variables control the map specific environment"
+        guistrut 1
         if (= $guipasses 0) [
             ambientval = (hexcolour $ambient)
             skylightval = (hexcolour $skylight)
@@ -379,8 +380,8 @@
             guitext "air coast"
         ]
         guistrut 0.5
-        guieditbutton "set up a skybox" [showgui skyboxes] 
-        guibutton "all world variables" [sleep 500 [varflags = 8; varsmore = 1]; showgui vars]
+        guieditbutton "find and set up a skybox (3d background) " [showgui skyboxes] 
+        guibutton "advanced search for world variables" [sleep 500 [varflags = 8; varsmore = 1]; showgui vars]
 
         guitab lighting
         guilist [ 
@@ -1095,17 +1096,6 @@
         ]
     ]
 
-    newgui newmapgui [
-            if (= $guipasses 0) [newmapsize = 12]
-            guibutton    "^foREVERT ^fwto last saved version of @savemap_name"      "map $savemap_name"
-            guitext " "
-            guibutton   "^foOPEN ^fwan existing map"                        "showgui maps 1"
-            guitext " "
-            guibutton    "^foCLEAR MAP ^fwand begin a new one ^fr(Warning!)"         "newmap $newmapsize"
-            guitext      "size of new map"
-            guislider    "newmapsize" 10 16
-    ]
-
     newgui texreset [
         guilist [
             guilist [
@@ -1134,12 +1124,6 @@
     ]
 
     newgui materials [
-        @matmenu
-    ]
-
-    newgui quickedit [
-        @quickeditmenu
-        guitab materials
         @matmenu
     ]
 


### PR DESCRIPTION
some quick fixes for #281:
remove quickedit menu (fixes an error message) and newmap menu (will recreate this one later)
improve descriptions in world menu, announce updates for later via guistatus
tweak compass/F3 menu: Toggle/quit editing as first option (Q), remove materials link for now (will go in a new tab of the world menu later)
---> the compass layout is much nicer this way, and we get THE important bind shown in these main menus