### PR TITLE
Change `return false` to `return` in loadalias

### DIFF
--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -495,7 +495,7 @@ void loadalias(const char *name, const char *fname)
     if(!buf)
     {
         conoutf("\frcould not read %s", fname);
-        return false;
+        return;
     }
     tagval v;
     v.setstr(buf);


### PR DESCRIPTION
Fixes a compiler error.