### PR TITLE
fix x-y-z entinfo on particle labels

### DIFF
--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -202,7 +202,7 @@ namespace entities
                                 case 24: case 25: case 26: addentinfo("plane-flat"); break;
                                 default: hasval = false; addentinfo("default"); break;
                             }
-                            if(hasval) switch(val%3)
+                            if(hasval) switch((val%32)%3)
                             {
                                 case 0: addentinfo("x-axis"); break;
                                 case 1: addentinfo("y-axis"); break;


### PR DESCRIPTION
I just had a first look at this, so i might be wrong, but I think the axis of the particle direction was not shown correctly for other values than 256 to 256+32. Not sure what your convention on the coordinate system is, though, but this gives at least the right "periodicity", you agree?