### PR TITLE
enhance the ents menu

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -995,7 +995,6 @@
         loop i (? $efuitype (getentattr $efuitype) 12) [
             [efuiattr@i] = "*"
         ]
-        if (=s $efuitypename particles) [efuiattr0 = 0]
     ]
     efuireset
     
@@ -1086,7 +1085,7 @@
                         if (=s $efuitypename particles) [guitext "attributes differ per type:"]
                         loop i (getentattr $efuitype) [
                             a = (getentattr $efuitype $i $efuiattr0) 
-                            if (stringlen $a) [
+                            if (|| (stringlen $a) (= $i 0)) [
                                 guilist [
                                     guifield [efuiattr@i] 11  
                                     guistrut 1
@@ -1170,10 +1169,12 @@
                         itype = (indexof $enttypelist (enttype))
                         guitext (format "%1 (index %2)" (enttype) (entindex))
                         guistrut 1
-                        if (=s $efuitypename particles) [guitext "attributes differ per type (attribute 1)"]
+                        if (=s (enttype) particles) [
+                            guibutton "pick direction and colour" [showgui particledir] -1 $editingtex
+                        ]
                         loop iattr (getentattr $itype) [
                             a = (getentattr $itype $iattr (entattr 0)) 
-                            if (stringlen $a) [
+                            if (|| (stringlen $a) (= $iattr 0)) [
                                 guilist [
                                     guifont emphasis [
                                     guibutton "+" [entprop @iattr 1]
@@ -1185,6 +1186,18 @@
                                     guifield field@iattr -10 [entattr @iattr (field@iattr)]
                                     guistrut 1
                                     guitext $a
+                                    guispring 1
+                                    if (=s $a colour) [
+                                        guibutton pick [colattr = @iattr; showgui entcolour] -1 $editingtex
+                                        guistrut 1
+                                    ]
+                                    if (=s $a dir) [
+                                        guibutton pick [showgui particledir] -1 $editingtex
+                                        guistrut 1
+                                    ]
+                                    if (< $iattr 12) [
+                                        guitext (dobindsearch (concat domodifier (+ 11 $iattr)) edit)
+                                    ]
                                 ]    
                             ]    
                         ]    
@@ -1202,6 +1215,81 @@
             ]
         ]
     ]
+
+
+    setdir = [entattr 1 (+ $offset (* 32 $i) (* 3 $shape) $axis)]
+    newgui particledir [ guistayopen [
+        guistatus "press ^fcEsc^fw when done to return to the previous menu"
+        if (= 0 $guipasses) [
+            t = (entattr 0)
+            hex = (entattr 3)
+            dir = (mod (entattr 1) 64)
+            if (> $dir 32) [
+                i = 1
+                dir = (- $dir 32)
+    
+            ] [
+                i = 0
+            ] 
+            axis = (mod $dir 3)
+            shape = (div $dir 3)
+            offset = 256
+        ]
+        guilist [
+            guilist [
+                guitext "type"
+                guistrut 0.5
+                looplist j [4 7 8 9 10 11 12 13] [
+                    guiradio (getentattr 5 0 $j) t $j [entattr 0 @j]
+                ]
+            ]
+            guistrut 2
+            guilist [
+                guitext "shape"
+                guistrut 0.5
+                guiradio circle shape 0 setdir
+                guiradio cylinder shape 1 setdir
+                guiradio cone-shell shape 2 setdir
+                guiradio cone-shell-2 shape 3 setdir
+                guiradio plane-volume shape 4 setdir
+                guiradio line-volume shape 5 setdir
+                guiradio line-volume-2 shape 6 setdir
+                guiradio sphere shape 7 setdir
+                guiradio plane-flat shape 8 setdir
+            ]
+            guistrut 2
+            guilist [
+                guitext "direction"
+                guistrut 0.5
+                guiradio x-axis axis 0 setdir
+                guiradio y-axis axis 1 setdir
+                guiradio z-axis axis 2 setdir
+                guistrut 1
+                guicheckbox inverted i 1 0 setdir
+            ]
+            //guistrut 2
+            //guilist [
+            //    guitext "test offset"
+            //    loop j 8 [
+            //        guiradio (* 64 $j) offset (* 64 $j) setdir
+            //    ]
+            //]
+        ]
+    ] ]
+
+    newgui entcolour [ guistayopen [
+        guistatus "press ^fcEsc^fw when done to return to the previous menu"
+        guitext (format "pick a colour for attribute %1 of the selected %2" $colattr (enttype))
+        guistrut 1
+        guilist [
+            guihexpreview $hex hex-value
+            guistrut 1
+            guilist [guirgbsliders hex]
+            guistrut 2
+            guibutton "apply this colour" [entattr @colattr @hex] -1 $editingtex
+        ]
+        guipalette 0.5
+    ] ]
 
     newgui sounds [ guistayopen [
         if (= 0 $guipasses) [


### PR DESCRIPTION
add a nice menu for particle shapes and directions
add colour picker menu for entities
add contextual pick buttons to edit tab of ents menu
do not hide the first ent attribute if the label is empty
show number binds when editing ent attributes