### PR TITLE
add {duel,survivor}maxqueued variables

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -328,6 +328,8 @@ setdesc "maxresizescale" "defines the largest scaled size a player can become in
 setdesc "maxcarry" "maximum number of weapons a player can carry, plus pistol and grenades" "<value>"
 setdesc "spawnhealth" "defines the amount of health you spawn with, and the maximum amount of health to which you will regenerate when damaged, assigning this variable a value of 0 or 1 will cause you to die in one hit" "<value>"
 setdesc "zoomtime" "determines how long it takes for the rifle scope to zoom in and out, the rifle uses the primary fire mode unless the scope is fully zoomed in" "<value>"
+setdesc "duelmaxqueued" "number of players that can be queued for duel. 0 = any number of players"
+setdesc "survivormaxqueued" "number of players that can be queued for survivor. 0 = any number of players"
 //material
 setdesc "editmat" "modifies the material properties for selected cubes;^n<type> is the material to be applied {water, clip, ladder, etc.},^n<filter> limits the command to only affect cubes whose material match this, if given as empty string ^"^" it matches all,^n<style> limits the command to only affect cubes whose geometry match this {0 = normal, 1 = non-empty, 2 = empty, 3 = not entirely solid, 4 = entirely solid},^nexample: editmat air water 2 would set all empty cubes with water within the current selection to instead be air" "<type> [<filter> <style>]"
 setdesc "showmat" "toggles the visibility of material volumes" "<value>"

--- a/src/game/duelmut.h
+++ b/src/game/duelmut.h
@@ -49,11 +49,13 @@ struct duelservmode : servmode
     {
         if(ci->state.actortype >= A_ENEMY || ci->state.state == CS_SPECTATOR) return;
         if(gamestate == G_S_OVERTIME && !restricted.empty() && restricted.find(ci) < 0) return;
-        if(DSGS(maxqueued) && duelqueue.find(ci) < 0 && playing.find(ci) < 0) {
+        if(DSGS(maxqueued) && duelqueue.find(ci) < 0 && playing.find(ci) < 0)
+        {
             int player_cnt = 0;
-            loopv(duelqueue) if (duelqueue[i]->state.actortype == A_PLAYER) ++player_cnt;
-            loopv(playing) if (playing[i]->state.actortype == A_PLAYER) ++player_cnt;
-            if(player_cnt >= DSGS(maxqueued)) {
+            loopv(duelqueue) if(duelqueue[i]->state.actortype == A_PLAYER) player_cnt++;
+            loopv(playing) if(playing[i]->state.actortype == A_PLAYER) player_cnt++;
+            if(player_cnt >= DSGS(maxqueued))
+            {
                 spectator(ci);
                 srvmsgft(ci->clientnum, CON_EVENT, "\fyyou \fs\fzgcCAN NOT\fS be queued. %s is \fs\fcFULL\fS. %d players maximum\fS",
                             m_duel(gamemode, mutators) ? "duel" : "survivor", DSGS(maxqueued));

--- a/src/game/duelmut.h
+++ b/src/game/duelmut.h
@@ -49,6 +49,17 @@ struct duelservmode : servmode
     {
         if(ci->state.actortype >= A_ENEMY || ci->state.state == CS_SPECTATOR) return;
         if(gamestate == G_S_OVERTIME && !restricted.empty() && restricted.find(ci) < 0) return;
+        if(DSGS(maxqueued) && duelqueue.find(ci) < 0 && playing.find(ci) < 0) {
+            int player_cnt = 0;
+            loopv(duelqueue) if (duelqueue[i]->state.actortype == A_PLAYER) ++player_cnt;
+            loopv(playing) if (playing[i]->state.actortype == A_PLAYER) ++player_cnt;
+            if(player_cnt >= DSGS(maxqueued)) {
+                spectator(ci);
+                srvmsgft(ci->clientnum, CON_EVENT, "\fyyou \fs\fzgcCAN NOT\fS be queued. %s is \fs\fcFULL\fS. %d players maximum\fS",
+                            m_duel(gamemode, mutators) ? "duel" : "survivor", DSGS(maxqueued));
+                return;
+            }
+        }
         if(ci->state.actortype == A_PLAYER && waitforhumans) waitforhumans = false;
         int n = duelqueue.find(ci);
         if(top)

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -27,6 +27,9 @@ GVAR(IDF_ADMIN, serveropen, 0, 3, 3);
 GSVAR(IDF_ADMIN, serverdesc, "");
 GSVAR(IDF_ADMIN, servermotd, "");
 
+GVAR(IDF_ADMIN, duelmaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for duel. 0 = any number of players
+GVAR(IDF_ADMIN, survivormaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for survivor. 0 = any number of players
+
 GVAR(IDF_ADMIN, autoadmin, 0, 0, 1);
 
 GVAR(IDF_ADMIN, queryinterval, 0, 5000, VAR_MAX); // rebuild client list for server queries this often

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -27,9 +27,6 @@ GVAR(IDF_ADMIN, serveropen, 0, 3, 3);
 GSVAR(IDF_ADMIN, serverdesc, "");
 GSVAR(IDF_ADMIN, servermotd, "");
 
-GVAR(IDF_ADMIN, duelmaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for duel. 0 = any number of players
-GVAR(IDF_ADMIN, survivormaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for survivor. 0 = any number of players
-
 GVAR(IDF_ADMIN, autoadmin, 0, 0, 1);
 
 GVAR(IDF_ADMIN, queryinterval, 0, 5000, VAR_MAX); // rebuild client list for server queries this often
@@ -261,6 +258,7 @@ GVAR(0, duelcycles, 0, 2, VAR_MAX); // maximum wins in a row before force-cyclin
 GVAR(0, duelaffinity, 0, 1, 2); // 0 = off, 1 = on enter can respawn next iter, 2 = on enter can respawn immediately
 GVAR(0, duelbotcheck, 0, 1, 1); // 0 = off, 1 = skip bots when checking respawns
 GVAR(0, duelovertime, 0, 1, 1); // 0 = off, 1 = ffa: only spawn leaders in overtime
+GVAR(0, duelmaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for duel. 0 = any number of players
 
 GVAR(0, survivorreset, 0, 1, 1); // reset winners in survivor
 GVAR(0, survivorclear, 0, 1, 1); // clear items in survivor
@@ -270,6 +268,7 @@ GVAR(0, survivorcooloff, 0, 3000, VAR_MAX); // cool off period before survivor g
 GVAR(0, survivoraffinity, 0, 0, 1); // 0 = off, 1 = on enter can spawn immediately
 GVAR(0, survivorbotcheck, 0, 1, 1); // 0 = off, 1 = skip bots when checking respawns
 GVAR(0, survivorovertime, 0, 1, 1); // 0 = off, 1 = ffa: only spawn leaders in overtime
+GVAR(0, survivormaxqueued, 0, 0, MAXCLIENTS); // number of players that can be queued for survivor. 0 = any number of players
 
 GVAR(0, pointlimit, 0, 0, VAR_MAX); // finish when score is this or more
 GVAR(0, teampersist, 0, 1, 2); // 0 = off, 1 = only attempt, 2 = forced


### PR DESCRIPTION
Adds two variables `duelmaxqueued` and `survivormaxqueued` that set maximum number of players that can be queued respectively for duel and survivor.