### PR TITLE
tweak colour preview for "UI voodoo"

### DIFF
--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -235,11 +235,11 @@ guirgbsliders = [
 guihexpreview = [
         guilist [
             guibackground $arg1 1 0xffffff 1
-            guistrut 0.5
-            guistrut 10 1
+            guistrut 0.9
+            guistrut 12 1
             guicenter [ guitext @arg2 ]
             guicenter [ guitext (hexcolour @arg1) ]
-            guistrut 0.5
+            guistrut 0.9
         ]
 ]
 
@@ -315,12 +315,12 @@ newgui pickcolour [ guistayopen [
     guistrut 1
     guilist [
         guibody [ guilist [
-            guihexpreview $$scurvar "current"
-        ] ] [hex = $$scurvar]
+            guihexpreview (getvardef $scurvar) "default"
+        ] ] [hex = (getvardef $scurvar)]
         guispring 1
         guibody [ guilist [
-            guihexpreview (getvardef $scurvar) "default"
-        ]] [hex = (getvardef $scurvar)]
+            guihexpreview $$scurvar "current"
+        ] ] [hex = $$scurvar]
         guispring 1
         guihexpreview $hex "new"
         guispring 1
@@ -335,3 +335,4 @@ newgui pickcolour [ guistayopen [
 ] ]
 
 pickcolour = [ scurvar = $arg1 ; showgui pickcolour ]
+


### PR DESCRIPTION
enlarge the colourboxes used in the profile, vars and help menus, such that they fit the new size of the sliders
restore 984ae1c by @IceflowRE - I guess it was accidentally reverted on the following commit