### PR TITLE
Initialize Authhandle

### DIFF
--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -854,6 +854,7 @@ void checkmaster()
             c->address = address;
             c->socket = masterclientsocket;
             c->lastactivity = totalmillis ? totalmillis : 1;
+            copystring(c->authhandle, "");
             masterclients.add(c);
             if(enet_address_get_host_ip(&c->address, c->name, sizeof(c->name)) < 0) copystring(c->name, "unknown");
             if(verbose) conoutf("master peer %s connected", c->name);


### PR DESCRIPTION
masterclient.authhandle was uninitialized, probably the cause of the weirdness of the master server's output.