### PR TITLE
Show if the server records statistics in the server browser.

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -75,7 +75,7 @@ servermenu = [
         sinfoflags = (getserver $i 0 9)
         sinfostatsflag = 0
         looplist fi $sinfoflags [
-            if (=s $fi "s") [ $sinfostatsflag = 1 ]
+            if (=s $fi "s") [ sinfostatsflag = 1 ]
         ]
         // attrs
         sinfoattr = (getserver $i 1 -1)

--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -72,6 +72,11 @@ servermenu = [
         sinfoping = (getserver $i 0 6)
         sinfolast = (getserver $i 0 7)
         sinfohandle = (getserver $i 0 8)
+        sinfoflags = (getserver $i 0 9)
+        sinfostatsflag = 0
+        looplist fi $sinfoflags [
+            if (=s $fi "s") [ $sinfostatsflag = 1 ]
+        ]
         // attrs
         sinfoattr = (getserver $i 1 -1)
         sinfogver = (getserver $i 1 0)
@@ -172,6 +177,9 @@ servermenu = [
                     guibutton (format "^fw%1" $sinfodesc)
                     guifont "little" [ guicenter [ guibutton (format "^fd(^fa%1^fd)" $sinfonpid) ] ]
                     guifont "little" [ guicenter [ guibutton (format "^fd[^fc%1^fd]" $sinfohandle) ] ]
+                    if $sinfostatsflag [
+                        guifont "little" [ guicenter [ guibutton "^fd[^fcstatistics^fd]" ] ]
+                    ]
                 ]
                 guispring 1
                 if $sinfoactive [

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -480,7 +480,7 @@ extern void localconnect(bool force = true);
 extern void localdisconnect();
 
 // serverbrowser
-extern void addserver(const char *name, int port, int priority = 0, const char *desc = NULL, const char *handle = NULL);
+extern void addserver(const char *name, int port, int priority = 0, const char *desc = NULL, const char *handle = NULL, const char *flags = NULL);
 
 // client
 extern char *connectname;

--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -733,7 +733,7 @@ bool checkmasterclientinput(masterclient &c)
             {
                 masterclient &s = *masterclients[j];
                 if(!s.listserver) continue;
-                masteroutf(c, "addserver %s %d %d %s %s\n", s.name, s.port, s.priority(), escapestring(s.desc), escapestring(s.authhandle));
+                masteroutf(c, "addserver %s %d %d %s %s %s\n", s.name, s.port, s.priority(), escapestring(s.desc), escapestring(s.authhandle), escapestring(s.flags));
                 servs++;
             }
             conoutf("master peer %s was sent %d server(s)", c.name, servs);

--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -220,7 +220,7 @@ bool sortedservers = true;
 ENetSocket pingsock = ENET_SOCKET_NULL;
 int lastinfo = 0;
 
-static serverinfo *newserver(const char *name, int port = SERVER_PORT, int priority = 0, const char *desc = NULL, const char *handle = NULL, uint ip = ENET_HOST_ANY)
+static serverinfo *newserver(const char *name, int port = SERVER_PORT, int priority = 0, const char *desc = NULL, const char *handle = NULL, const char *flags = NULL, uint ip = ENET_HOST_ANY)
 {
     serverinfo *si = new serverinfo(ip, port, priority);
 
@@ -232,6 +232,7 @@ static serverinfo *newserver(const char *name, int port = SERVER_PORT, int prior
     }
     if(desc && *desc) copystring(si->sdesc, desc);
     if(handle && *handle) copystring(si->authhandle, handle);
+    if(flags && *flags) copystring(si->flags, flags);
 
     servers.add(si);
     sortedservers = false;
@@ -239,13 +240,13 @@ static serverinfo *newserver(const char *name, int port = SERVER_PORT, int prior
     return si;
 }
 
-void addserver(const char *name, int port, int priority, const char *desc, const char *handle)
+void addserver(const char *name, int port, int priority, const char *desc, const char *handle, const char *flags)
 {
     loopv(servers) if(!strcmp(servers[i]->name, name) && servers[i]->port == port) return;
-    if(newserver(name, port, priority, desc, handle) && verbose >= 2)
+    if(newserver(name, port, priority, desc, handle, flags) && verbose >= 2)
         conoutf("added server %s (%d) [%s]", name, port, desc);
 }
-ICOMMAND(0, addserver, "siiss", (char *n, int *p, int *r, char *d, char *h), addserver(n, *p > 0 ? *p : SERVER_PORT, *r >= 0 ? *r : 0, d, h));
+ICOMMAND(0, addserver, "siiss", (char *n, int *p, int *r, char *d, char *h, char *f), addserver(n, *p > 0 ? *p : SERVER_PORT, *r >= 0 ? *r : 0, d, h, f));
 
 VAR(0, searchlan, 0, 0, 1);
 VAR(IDF_PERSIST, maxservpings, 0, 10, 1000);
@@ -348,7 +349,7 @@ void checkpings()
         if(len <= 0) return;
         serverinfo *si = NULL;
         loopv(servers) if(addr.host == servers[i]->address.host && addr.port == servers[i]->address.port) { si = servers[i]; break; }
-        if(!si && searchlan) si = newserver(NULL, addr.port-1, 1, NULL, NULL, addr.host);
+        if(!si && searchlan) si = newserver(NULL, addr.port-1, 1, NULL, NULL, NULL, addr.host);
         if(!si) continue;
         ucharbuf p(ping, len);
         int millis = getint(p), rtt = clamp(totalmillis - millis, 0, min(serverdecay*1000, totalmillis));

--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -246,7 +246,7 @@ void addserver(const char *name, int port, int priority, const char *desc, const
     if(newserver(name, port, priority, desc, handle, flags) && verbose >= 2)
         conoutf("added server %s (%d) [%s]", name, port, desc);
 }
-ICOMMAND(0, addserver, "siiss", (char *n, int *p, int *r, char *d, char *h, char *f), addserver(n, *p > 0 ? *p : SERVER_PORT, *r >= 0 ? *r : 0, d, h, f));
+ICOMMAND(0, addserver, "siisss", (char *n, int *p, int *r, char *d, char *h, char *f), addserver(n, *p > 0 ? *p : SERVER_PORT, *r >= 0 ? *r : 0, d, h, f));
 
 VAR(0, searchlan, 0, 0, 1);
 VAR(IDF_PERSIST, maxservpings, 0, 10, 1000);

--- a/src/game/auth.h
+++ b/src/game/auth.h
@@ -408,7 +408,7 @@ namespace auth
         else
         {
             conoutf("updating master server");
-            requestmasterf("server %d %s %d %s\n", serverport, *serverip ? serverip : "*", CUR_VERSION, escapestring(G(serverdesc)));
+            requestmasterf("server %d %s %d %s %d\n", serverport, *serverip ? serverip : "*", CUR_VERSION, escapestring(G(serverdesc)), G(serverstats));
         }
         reqserverauth();
     }

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -3186,6 +3186,7 @@ namespace client
                         case 6: intret(si->ping); break;
                         case 7: intret(si->lastinfo); break;
                         case 8: result(si->authhandle); break;
+                        case 9: result(si->flags); break;
                     }
                     break;
                 case 1:

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -480,7 +480,7 @@ struct serverinfo
     };
     enum { UNRESOLVED = 0, RESOLVING, RESOLVED };
 
-    string name, map, sdesc, authhandle;
+    string name, map, sdesc, authhandle, flags;
     int numplayers, lastping, lastinfo, nextping, ping, resolved, port, priority;
     int pings[MAXPINGS];
     vector<int> attr;
@@ -490,7 +490,7 @@ struct serverinfo
     serverinfo(uint ip, int port, int priority = 0)
      : numplayers(0), resolved(ip==ENET_HOST_ANY ? UNRESOLVED : RESOLVED), port(port), priority(priority)
     {
-        name[0] = map[0] = sdesc[0] = authhandle[0] = 0;
+        name[0] = map[0] = sdesc[0] = authhandle[0] = flags[0] = 0;
         address.host = ip;
         address.port = port+1;
         clearpings();


### PR DESCRIPTION
This sends the flags to the server browser, filtering out `s` if the server has `serverstats` set to 0.