### PR TITLE
Collect handle in m_laptime disconnect game ends, be sure game has started in sendstats()

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3096,7 +3096,7 @@ namespace server
 
     void sendstats()
     {
-        if(G(serverstats) && auth::hasstats && !sentstats)
+        if(G(serverstats) && auth::hasstats && !sentstats && gamemillis)
         {
             sentstats = true;
             requestmasterf("stats begin\n");
@@ -4942,6 +4942,7 @@ namespace server
         {
             if(m_demo(gamemode)) enddemoplayback();
         }
+        if(complete && ci->connected) if(m_laptime(gamemode, mutators)) sendstats();
         if(ci->connected)
         {
             if(reason != DISC_SHUTDOWN)
@@ -4975,7 +4976,6 @@ namespace server
         else connects.removeobj(ci);
         if(complete)
         {
-            if(m_laptime(gamemode, mutators)) sendstats();
             cleanup();
         }
         else shouldcheckvotes = true;


### PR DESCRIPTION
This fixes where the handle of a player is not recorded when he disconnects in m_laptime, as well as where a game is sent before it even starts.