### PR TITLE
revamp the clients menu

### DIFF
--- a/config/menus/game.cfg
+++ b/config/menus/game.cfg
@@ -21,196 +21,213 @@ newgui team [
     guitip (format "press %1 to open this menu at any time" (dobindsearch "showgui team"))
 ]
 
-cnsel = (getclientnum)
-weaptex = "textures/question"
-loop i $weapidxloadout [append (format "textures/weapons/%1" $i)]
-showbots = 0
-client_tab = [
-    guilist [
-        guilist [
-            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
-            guistrut 0.2
-            guilist [
-                guistrut 0.2
-                guicheckbox "include bots" showbots
-                guistrut 0.6
-            ]
-            guistrut 0.5
-            if (= $showbots 1) [
-                cnlist = (listclients 1)
-            ] [
-                cnlist = (listdel (listclients 1) (listclients 0 2))
-            ]
-                loop i 5 [
-                    looplist cn ($cnlist)  [
-                        if (= (getclientteam $cn) $i) [guilist [guistrut 0.2; guiradio (getclientname $cn 1) cnsel $cn; guistrut 0.4]]
-                    ]
-                ]
-            guistrut 0.3
+trimstring = [
+    // trims arg1 to textwidth $arg2
+    // a proper function may be more efficient 
+    if (> (textwidth $arg1) $arg2) [
+        local str w l
+        str = $arg1
+        l = (stringlen $str)
+        w = (- $arg2 (textwidth "..."))
+        loopwhile i 1000 [ > (textwidth $str) $w] [
+            l = (- $l 1)
+            str = (substring $str 0 $l)
         ]
-
-        clempty = (! (getclientpresence $cnsel))
-        clname = (? $clempty "empty" (getclientname $cnsel))
-        clcname = (? $clempty "empty" (getclientname $cnsel 1))
-        clmodel = (? $clempty 0 (getclientmodel $cnsel))
-        clcolour = (? $clempty 0 (getclientcolour $cnsel))
-        clteam = (? $clempty 0 (getclientteam $cnsel))
-        clweap = (? $clempty 0 (getclientweapselect $cnsel))
-        clvanity = (? $clempty "" (getclientvanity $cnsel))
-        cltab = (format "\f[%1]%2" (? $clempty 0x111111 $clcolour) $cnsel)
-        guistrut 2
-        guilist [
-            guifont play [guitext $clcname]
-            guinohitfx [ guiplayerpreview $clmodel $clcolour $clteam $clweap $clvanity [] 7.5 1 1]
-            row = 0
-            itemp = $maxcarry    //prepare while; itemp: remaining weapons
-            while [> $itemp 0] [
-                guicenter [ guilist [ guilist [
-                    loop i (if (> $itemp 4) [result 4] [result $itemp]) [
-                        wi = (getclientloadweap $cnsel (+ $i (* $row 4)))
-                        if (> $wi 0) [
-                            wi = (at $weapname $wi)
-                            guinohitfx [guiimage textures/weapons/@[wi] [] 1.85 1 "" [] $[@[wi]colour] ]
-                        ] [
-                            guiimage textures/question [] 1.85 1 "" [] 0xaaaaaa
-                        ]
-                    ]
-                ] ] ]
-                row = (+ $row 1)
-                itemp = (- $itemp 4)
-            ]
-        ]
-        guistrut 1
-        guilist [
-            guistrut 0.6
-
-            guilist [ guibackground [0x202020] $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1; guistrut 0.5; guilist [
-                guistrut 0.2
-                guilist [ guitext "Handle" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclienthandle $cnsel)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no handle" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "IP" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclienthost $cnsel)
-                guilist [ guistrut 1; if $content [if (=s $content "unknown") [guitext "localhost"] [guitext $content]] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "Clientnumber" [] [0xDD9999]; guistrut 0.4 ]
-                content = $cnsel
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "RE version" [] [0xDD9999]; guistrut 0.4 ]
-                content = (stringreplace (loopconcat i 3 [getclientversion $cnsel $i]) " " ".")
-                guilist [ guistrut 1; if $content [guitext $content [] -1 -1 600] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "Game version" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientversion $cnsel 3)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "Platform/ Architecture" [] [0xDD9999]; guistrut 0.4 ]
-                content = (
-                    case (getclientversion $cnsel 4
-                        ) 0 [ result "Windows"
-                        ] 1 [ result "OS X"
-                        ] 2 [ result "Unix-like"
-                    ]
-                )
-                content = (concat $content (concatword (getclientversion $cnsel 5) "bit"))
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "OpenGL version/ OpenGL shader version" [] [0xDD9999]; guistrut 0.4 ]
-                content = (concatword (getclientversion $cnsel 6) "/ " (getclientversion $cnsel 7) )
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "CRC" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientversion $cnsel 8)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "GPU vendor" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientversion $cnsel 9)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "GPU" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientversion $cnsel 10)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "GPU version" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientversion $cnsel 11)
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guistrut 0.2
-            ] ]
-        ]
-        guistrut 2
-        guilist [
-            guilist [ guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1; guistrut 0.5; guilist [
-                guilist [ guitext "Chat" [] [0x9999DD]; guistrut 0.4 ]
-                guilist [ guistrut 0.7; guibutton "Paste name to chat" [saycommand  (getclientname $cnsel)] [] "textures/chat"; guistrut 2] 
-                guilist [ guistrut 0.7; guibutton "whisper   " [saycommand  /whisper $cnsel  ] [] "textures/chat" ]
-                if (! (& (mutators) $mutsbitffa)) [
-                    guitext "Change team" [] [0x9999DD]
-                    guilist [ guistrut 0.7; guibutton (format "^f[%1]^f(%2) " $teamalphacolour $teamalphatex) [saycommand /setteam $cnsel alpha] ]
-                    guilist [ guistrut 0.7; guibutton (format "^f[%1]^f(%2) " $teamomegacolour $teamomegatex) [saycommand /setteam $cnsel omega] ]
-                    if (& (mutators) $mutsbitmulti )[
-                        guilist [ guistrut 0.7; guibutton (format "^f[%1]^f(%2) " $teamkappacolour $teamkappatex) [saycommand /setteam $cnsel kappa] ]
-                        guilist [ guistrut 0.7; guibutton (format "^f[%1]^f(%2) " $teamsigmacolour $teamsigmatex) [saycommand /setteam $cnsel sigma] ]
-                    ]
-                ]
-                guitext "Moderation" [] [0x9999DD]
-                if (! (& (mutators) $mutsbitffa)) [
-                    guilist [ guistrut 0.7; guibutton  "limit" [saycommand /limit $cnsel] [] $warningtex ]
-                ]
-                guilist [ guistrut 0.7; guibutton "mute!   " [saycommand /mute $cnsel ] [] $chattex ]
-                guilist [ guistrut 0.7; guibutton "kick!   " [saycommand /kick $cnsel ] [] $meleetex ]
-                guilist [ guistrut 0.7; guibutton "ban!    " [saycommand /ban $cnsel ] [] $warningtex ]
-                guistrut 0.3
-            ] ]
-            guistrut 0.8
-            guilist [ guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1; guistrut 0.5; guilist [
-                guistrut 0.2
-                guilist [ guitext "Playermodel" [] [0xDD9999]; guistrut 0.4 ]
-                content = (getclientmodel $cnsel)
-                content = (
-                    case (getclientmodel $cnsel
-                        ) 0 [ result "Male"
-                        ] 1 [ result "Female"
-                    ]
-                )
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                guilist [ guitext "Colour" [] [0xDD9999]; guistrut 0.4 ]
-                content = (hexcolour (getclientcolour $cnsel))
-                guilist [ guistrut 1; if $content [guitext $content] [guitext "no information available" [] [0xABABAB]]; guistrut 0.4 ]
-                
-                guilist [ guitext "Vanity items" [] [0xDD9999]; guistrut 0.4 ]
-                content = $clvanity
-                if $content [ //when there are vanities
-                    if (> (listlen $content) 7) [ //when there are more then 7 vanities use a guislider
-                        guilist [
-                            guistrut 1
-                            guilist [
-                                loopcount = 0
-                                looplist i (sublist $content $vanityindex 7) [ //lists all vanities
-                                    guistrut
-                                    guitext $i
-                                    loopcount = (+ $loopcount 1)
-                                    if (= $loopcount 7) [
-                                        guistrut 0.4
-                                    ]
-                                ]
-                            ]
-                            guispring 1
-                            guislider vanityindex 0 (- (listlen $content) 7) [] 1 1
-                        ]
-                        guistrut 0.2
-                    ][ //less or 9 vanities
-                        looplist i $content [
-                            guilist  [
-                                guistrut 1
-                                guitext $i [] -1 -1 1000
-                            ]
-                        ]
-                        guistrut 0.4
-                    ]
-                ][ //no vanity
-                    guilist [
-                        guistrut 1
-                        guitext "no vanities" [] [0xABABAB]
-                    ]
-                    guistrut 0.4
-                ]
-                guistrut 20.4 1    //making so width as the box upper
-            ] ]
-        ]
+        result  (concatword $str "^fa...")
+    ] [
+        result $arg1
     ]
 ]
+
+// client info menu
+showbots = 0
+reason = ""
+client_tab = [
+    clempty = (! (getclientpresence $cnsel))
+    clname = (? $clempty "empty" (getclientname $cnsel))
+    clcname = (? $clempty "empty" (getclientname $cnsel 1))
+    clmodel = (? $clempty 0 (getclientmodel $cnsel))
+    clcolour = (? $clempty 0 (getclientcolour $cnsel))
+    clteam = (? $clempty 0 (getclientteam $cnsel))
+    clweap = (? $clempty 0 (getclientweapselect $cnsel))
+    clvanity = (? $clempty "" (getclientvanity $cnsel))
+    //cltab = (format "\f[%1]%2" (? $clempty 0x111111 $clcolour) $cnsel)
+    guilist [
+        guifont play [guitext (format "selected: cn %1 %2" $cnsel (getclienthandle $cnsel))]
+        guispring 1
+        guicheckbox "include bots" showbots
+    ]
+    guifont play [guitext $clcname]
+    guilist [
+        // preview with profile tooltip
+        guibody [
+            guinohitfx [ guiplayerpreview $clmodel $clcolour $clteam $clweap $clvanity [] 7.5 1 1]
+        ] [] [] [
+            guitooltip (concat "colour:" (hexcolour $clcolour) "^nmodel:" (? $clmodel "female" "male" ) "^nvanities:^n" $clvanity) 900
+        ]
+        guistrut 1
+        // full loadout weaps with border around the current weapon
+        guilist [
+            guistrut 0.5
+            loop i $weapidxloadout [
+                wi = (getclientloadweap $cnsel $i)
+                if (> $wi 0) [
+                    wn = (at $weapname $wi)
+                    guinohitfx [guiimage textures/weapons/@[wn] [] 1 (= $wi (getclientweapselect $cnsel)) "" [] $[@[wn]colour]]
+                ] [
+                    guinohitfx [guiimage textures/question [] 1 0 "" [] 0xaaaaaa] // random / no preference
+                ]
+            ]
+            guistrut -0.5
+        ]
+        guistrut 2
+        guilist [
+            guistrut 0.5
+            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
+            guistrut 0.5
+            guilist [
+                guistrut 1.5
+                guilist [
+                    guistrut 12 1
+                    guitext "Host (tooltips)" "" 0xDD9999
+                    content = (getclienthost $cnsel)
+                    if $content [if (=s $content "unknown") [content = "localhost"] []] [content = "no information available"] 
+                    guibody [ guitext "IP/host"] [] [] [guitooltip $content]
+                    content = (stringreplace (loopconcat i 3 [getclientversion $cnsel $i]) " " ".")
+                    guibody [ guitext "RE version"] [] [] [guitooltip $content]
+                    content = (getclientversion $cnsel 3)
+                    guibody [ guitext "Game version"] [] [] [guitooltip $content]
+                    content = (
+                        case (getclientversion $cnsel 4
+                            ) 0 [ result "Windows"
+                            ] 1 [ result "OS X"
+                            ] 2 [ result "Unix-like"
+                        ]
+                    )
+                    content = (concat $content (concatword (getclientversion $cnsel 5) "bit"))
+                    guibody [ guitext "Platform"] [] [] [guitooltip $content] 
+                    content = (concatword (getclientversion $cnsel 6) "/ " (getclientversion $cnsel 7) )
+                    guibody [ guitext "OpenGL"] [] [] [guitooltip $content]
+                    content = (getclientversion $cnsel 8)
+                    guibody [ guitext "CRC"] [] [] [guitooltip $content]
+                    content = (getclientversion $cnsel 9)
+                    guibody [ guitext "GPU vendor"] [] [] [guitooltip $content]
+                    content = (getclientversion $cnsel 10)
+                    guibody [ guitext "GPU model"] [] [] [guitooltip $content]
+                    content = (getclientversion $cnsel 11)
+                    guibody [ guitext "GPU version"] [] [] [guitooltip $content]
+                ]
+                guistrut 1.5
+            ] 
+            guistrut 0.5
+        ]
+        guistrut 2
+        guilist [
+            guistrut 0.5
+            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
+            guistrut 0.5
+            guilist [
+                guistrut 1.5
+                guilist [
+                    guitext "Chat" [] [0x9999DD]
+                    guibutton "paste name" [saycommand @(getsaycolour)@clname, ""] [] "textures/chat"
+                    guibutton "whisper   " [saycommand /whisper $cnsel ""] [] "textures/chat"
+                    if (ismoderator $getclientnum) [
+                        guitext "Moderation" [] [0x9999DD]
+                        guifield reason -10 [] -1 0 "" 0 "^fd/reason = ..."
+                        guibutton "warn" [saycommand "^fzyw"@[clname], $reason ] [] $waitingtex
+                    ]
+                    if (getclientpriv $getclientnum $mutelock) [
+                        guibutton "mute" [saycommand /mute $cnsel $reason] [] $chattex 
+                    ]
+                    if (getclientpriv $getclientnum $speclock) [
+                        if (isquarantine $cnsel) [
+                            guibutton "^fzgwrelease" [saycommand /spectator 0 $cnsel] [] $spectatortex 
+                        ] [
+                            guibutton "quarantine" [saycommand /spectator 2 $cnsel] [] $spectatortex 
+                        ]
+                    ]
+                    if (getclientpriv $getclientnum $kicklock) [
+                        guibutton "kick" [saycommand /kick $cnsel $reason] [] $meleetex 
+                    ]
+                    if (getclientpriv $getclientnum $banlock) [
+                        guibutton "ban!" [saycommand /ban $cnsel $reason] [] $warningtex 
+                    ]
+                    if (getclientpriv $getclientnum $teamlock) [
+                        if (! (& (mutators) $mutsbitffa)) [
+                            guitext "team / limit" [] 
+                            guilist [
+                                guibutton " " [saycommand /setteam $cnsel alpha] [] $teamalphatex -1 $teamalphacolour
+                                guibutton " " [saycommand /setteam $cnsel omega] [] $teamomegatex -1 $teamomegacolour
+                                if (& (mutators) $mutsbitmulti )[
+                                    guibutton " " [saycommand /setteam $cnsel kappa] [] $teamkappatex -1 $teamkappacolour
+                                    guibutton " " [saycommand /setteam $cnsel sigma] [] $teamsigmatex -1 $teamsigmacolour
+                                ]
+                                if (getclientpriv $getclientnum $limitlock) [
+                                    guibutton  " " [saycommand /limit $cnsel $reason] [] $waitingtex 0x666666
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+                guistrut 1.5
+            ]
+            guistrut 0.5
+        ]
+    ]
+    guistrut 1
+    // client selection
+    if $showbots [
+        cnlist = (listclients 1)
+    ] [
+        cnlist = (listdel (listclients 1) (listclients 0 2))
+    ]
+    if (& (mutators) $mutsbitffa) [
+        // FFA layout, save space with three cols
+        guilistsplit cn 3 $cnlist [
+            guistrut 25 1
+            content = (getclientname $cn 1)
+            guiradio (trimstring $content 1250) cnsel $cn
+        ]
+    ] [
+        i = 0 // team index
+        teamneutraltex = $spectatortex
+        if (& (mutators) $mutsbitmulti) [ // 4 teams
+            guilist [
+                looplist t [neutral alpha omega kappa sigma] [
+                    guilist [
+                        guistrut 15 1
+                        guitext $[team@[t]name] $[team@[t]tex] $[team@[t]colour] $[team@[t]colour] 
+                        looplist cn ($cnlist)  [
+                            if (= (getclientteam $cn) $i) [
+                                content = (getclientname $cn 1)
+                                guiradio (trimstring $content 750) cnsel $cn
+                            ]
+                        ]
+                    ]
+                    i = (+ $i 1)
+                ]
+            ]
+        ] [ // 2 teams
+            guilist [
+                looplist t [neutral alpha omega] [
+                    guilist [
+                        guistrut 25 1
+                        guitext $[team@[t]name] $[team@[t]tex] $[team@[t]colour] $[team@[t]colour] 
+                        looplist cn ($cnlist)  [
+                            if (= (getclientteam $cn) $i) [
+                                content = (getclientname $cn 1)
+                                guiradio (trimstring $content 1250) cnsel $cn
+                            ]
+                        ]
+                    ]
+                    i = (+ $i 1)
+                ]
+            ]
+        ] 
+    ] 
+]
+
 overview_tab = [
 guicenter [ guilist [
     guistrut 0.4
@@ -286,7 +303,9 @@ guicenter [ guilist [
         ]
     ] ]
 ]
+
 newgui clients [
+    if (= $guipasses 0) [cnsel = $getclientnum]
     guiheader "Clients"
         [client_tab]
     guitab "Overview"


### PR DESCRIPTION
clean up the code and keep a fixed layout (no horizontal jumps) 
check permissions for all moderator buttons
expand moderation: support for reasons, warn, quarantine, limit
support saycolour for pasting client names to chat, add space to whisper
add trimstring function for long player names to keep a nice layout
arrange client selection in one column per team (including neutral)
use guilistsplit for 3 columns in FFA
show full loadout selection and current weapon
show profile info as tooltip on modelpreview
show host/hardware info as tooltips to save space and make it less spoilerish
keep the overview by @iceflower as is