### PR TITLE
revamp mapmodel menu, scrap coopedit notification

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -657,17 +657,35 @@
 
     newgui cloudlayer [ guistayopen [
         guistatus "press ^fcEsc^fw when done to return to the previous menu"
-        guilistloop 4 3 (listlen $cloudlist) [
-            p = (at $cloudlist $i)
-            guiimage $p [cloudlayer @p] 3 (=s $cloudlayer $p) "" [saycommand /cloudlayer @p] 
+        if (= 0 $guipasses) [
+            slider = 0
+            imax = (listlen $cloudlist)
+        ] 
+        slidermax = (max (- $imax 5) 0)
+        guicenter [
+            loop i (min 5 $imax) [
+                j = (+ $i $slider)
+                p = (at $cloudlist $j)
+                guiimage $p [cloudlayer @p] 3 (=s $cloudlayer $p) "" [saycommand /cloudlayer @p] 
+            ]
+            if (slidermax) [guislider slider 0 $slidermax [] 1 1]
         ]
     ] ]
 
     newgui envlayer [ guistayopen [
         guistatus "press ^fcEsc^fw when done to return to the previous menu"
-        guilistloop 4 3 (listlen $cloudlist) [
-            p = (at $cloudlist $i)
-            guiimage $p [envlayer @p] 3 (=s $envlayer $p) "" [saycommand /envlayer @p] 
+        if (= 0 $guipasses) [
+            slider = 0
+            imax = (listlen $cloudlist)
+        ] 
+        slidermax = (max (- $imax 5) 0)
+        guicenter [
+            loop i (min 5 $imax) [
+                j = (+ $i $slider)
+                p = (at $cloudlist $j)
+                guiimage $p [envlayer @p] 3 (=s $envlayer $p) "" [saycommand /envlayer @p] 
+            ]
+            if (slidermax) [guislider slider 0 $slidermax [] 1 1]
         ]
     ] ]
 

--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -284,35 +284,7 @@
         ]
     ] ]
 
-    coopeditnotify = 1
-    newgui coopedit [ guistayopen [
-        guitext "some operations are ^fyNOT available"
-        guitext "when other players join the game:"
-        guistrut 0.5
-        guieditbutton "^fyundo" [undo; passthroughsel 0]
-        guieditbutton "^fyredo" redo
-        guitext "use of geometry ^fyprefabs"
-        guitext "use of ^fyheightmap mode"
-        guitext "adding texture variations (e.g. ^fyvcolour^fw)"
-        // what else?
-        guistrut 1.5
-        guitext "also, please be careful with operations" 
-        guitext "that cause waiting times for other players:"
-        guistrut 0.5
-        guieditbutton "optimize the geometry" remip
-        guieditbutton "patch existing lightmap" [fullbright 0; patchlight]
-        guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
-        guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
-        guistrut 1
-        guicenter [ guifont emphasis [ guibutton "^fgOK" [
-            coopeditnotify = 0
-            cleargui 1
-        ] ] ]
-    ] ]
-    
-
     newgui geometry [ guistayopen [
-        if (&& $isonline $coopeditnotify) [showgui coopedit]
         guistrut 0.5
         guistatus "some buttons have tooltips and alt-actions for console commands"
         guieditbutton "undo" [undo; passthroughsel 0]
@@ -797,7 +769,6 @@
     ] ]
 
     newgui textures [ guistayopen [
-        if (&& $isonline $coopeditnotify) [showgui coopedit]
         guistatus "some buttons have tooltips and alt-actions for console commands"
         if (= $guipasses 0) [varpix = 32 ; vara = 0.5; vara2 = 0.0]
         guistrut 0.5
@@ -1492,6 +1463,51 @@
         ] 
     ] ]
 
+    mapmodelprevs = 1
+    newgui mapmodels [ guistayopen [
+        if (= 0 $guipasses) [
+            slider = 0
+            imax = (mapmodelindex)
+        ] 
+        if (imax) [
+            guitext "^fapick a mapmodel entity to create"
+            guicheckbox "show previews" mapmodelprevs
+            guistrut 1
+            if $mapmodelprevs [
+                slidermax = (max (- $imax 4) 0)
+                guicenter [
+                    loop i (min 4 $imax) [
+                        j = (+ $i $slider)
+                        p = (mapmodelindex $j)
+                        guilist [
+                            guimodelpreview $p "mapmodel" [newent mapmodel @j] 6 1 
+                            guieditbutton (concat " " $p) [newent mapmodel @j] 
+                        ]
+                    ]
+                    if (slidermax) [guislider slider 0 $slidermax [] 1 1]
+                ]
+            ] [
+                slidermax = (max (- $imax 15) 0)
+                guicenter [
+                    guilist [
+                        guistrut 20 1
+                        loop i (min 15 $imax) [
+                            j = (+ $i $slider)
+                            p = (mapmodelindex $j)
+                            if $mapmodelprevs [
+                                guimodelpreview $p "mapmodel" [newent mapmodel @j] 5 1 
+                            ]
+                            guieditbutton $p [newent mapmodel @j] 
+                        ]
+                    ]
+                    if (slidermax) [guislider slider 0 $slidermax [] 1 1]
+                ]
+            ]
+        ] [
+            guitext "no mapmodels found for this map configuration"
+        ]
+    ] ]
+
     newgui lights [ guistayopen [
         if (= 0 $guipasses) [ hex = 0xffffff; rad = 64 ]
         guistrut 1
@@ -1610,38 +1626,4 @@
                     guifield obit@i -22
             ]
         ]
-    ]
-
-    mapmodelprevs = 3
-    mapmodelprevs3d = 0
-
-    alias showmapmodel [
-        mapmodelpath = (mapmodelindex $arg1)
-        mapmodelshot = (concatword $mapmodelpath "/thumb")
-        mapmodelcmd = (concat newent mapmodel $arg1)
-        guilistx 2 [
-            guilist [
-                if (mapmodelprevs) [
-                    if (mapmodelprevs3d) [
-                        guimodelpreview $mapmodelpath "mapmodel" $mapmodelcmd $mapmodelprevs 1
-                    ] [
-                        guiimage $mapmodelshot $mapmodelcmd $mapmodelprevs 1 "textures/nothumb"
-                    ]
-                ]
-            ]
-            guibutton $mapmodelpath $mapmodelcmd
-        ]
-    ]
-
-    newgui mapmodels [
-        guilist [
-            guicheckbox "show previews" mapmodelprevs 3 0
-            guistrut 2
-            guicheckbox "rotating (can take a while to load)" mapmodelprevs3d
-            guistrut 2
-            guitext "change size "
-            guifield mapmodelprevs 1
-        ]
-        mapmodelnum = (mapmodelindex)
-        guilistloop 4 (? $mapmodelprevs 2 8) $mapmodelnum [ showmapmodel $i ]
     ]


### PR DESCRIPTION
remove the old mapmodel menu with the thumbnails - they caused a serious fps drop if there were many models (!)
offer two layouts for a new mapmodel menu: Simple list view or horizontal scrolling with 4 previews each

thanks to 3bb72ad by @lsalzman, vslots and undo are available in coopedit - awesome! So let us remove the notification menu here
multiplayer use of prefabs and heightmaps is really not important to note, and maybe even that will be available later