### PR TITLE
fix tooltip in loadout menu

### DIFF
--- a/config/menus/profile.cfg
+++ b/config/menus/profile.cfg
@@ -185,9 +185,9 @@ newgui profile [
                                 w5 = (at $weapname $w4)
                                 guibutton (format "%1" $[@[w5]longname]) [loadweaps 0 (+ $weapidxoffset @w1)] [loadweaps 1 (+ $weapidxoffset @w1)] "" $[@[w5]colour]
                                 cases $guirollovername "random" [
-                                    guitooltip "You will get a random weapon each time you spawn"
+                                    guitooltip "You will get a random weapon each time you spawn" 1500
                                 ] (format "%1" $[@[w5]longname]) [
-                                  guitooltip (concatword "Primary: " $[@[w5]desc1] "^n" "Secondary: " $[@[w5]desc2])
+                                  guitooltip (format "^f[%1]primary mode:^n^fw%2^n^f[%1]secondary mode:^n^fw%3" $[@[w5]colour] $[@[w5]desc1] $[@[w5]desc2]) 1500
                                 ]
                                 guispring 1
                             ]


### PR DESCRIPTION
There are tooltips on the weapon names with descriptions in the loadout menu
(a feature i did not notice so far).
However, the two lines are in most cases too long to fit on the screen, so:
use text wrap (1500) and tweak the format a bit (colour).