### PR TITLE
improve editing menu: world

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -417,91 +417,6 @@
         ]
         guistrut 0.5
 
-        guitab sky
-        guitext "create a background scenery"
-        guistrut 1
-        if (concatword $skybox $cloudbox $cloudlayer $envlayer) [
-            guilist [
-                guispring 1
-                looplist j [colour blend spin yaw glare] [
-                    guitext (tabify $j 2)
-                ]
-            ]
-        ] [
-            guiright [guitext "enable a box a or layer to show more options"]
-        ]
-        looplist i [sky cloud cloudlayer envlayer] [
-            b = "box"
-            if (< -1 (stringstr $i layer)) [b = ""]
-            guilist [
-                guibutton [@i@b] [showgui [@@i@@b]] [saycommand /showgui [@@i@@b]] $editingtex
-                guispring 
-                if $[@i@b] [
-                    guibutton "pick" [pickcolour @@[i]colour] [] $editingtex $[@[i]colour]
-                    guistrut 2
-                    guifield [@[i]blend] 6
-                    guistrut 1
-                    looplist j [spin yaw] [
-                        // one exception: spin/yawclouds, not cloud
-                        if (=s $i cloud) [
-                            guifield [@[j]clouds] 6
-                        ] [
-                            guifield [@j@i] 6
-                        ]
-                        guistrut 1
-                    ]
-                    guicheckbox " " [@[i]glare] 
-                    guistrut 3
-                    guiimage $guiexittex [[@@i@@b] ""] 0.5
-                ] [
-                    // guifield $i 40
-                ]
-            ]
-        ]
-        guistrut 1
-        if (concatword $cloudlayer $envlayer) [
-            guilist [
-                looplist j [fade height scrollx scrolly scale subdiv] [ // offset is not interesting, is it?
-                    guitext (tabify $j 2)
-                ]
-                guispring
-                guitext layer
-            ]
-        ] [
-            guiright [guitext "enable a layer to show more options"]
-        ]
-        looplist i [cloud env] [ 
-            guilist [
-                if $[@[i]layer] [
-                    looplist j [fade height scrollx scrolly scale subdiv] [
-                        guifield [@i@j] 6
-                        guistrut 1
-                    ]
-                ] [
-                    // guifield $i 40
-                ]
-                    guispring 1
-                    guibutton $i [showgui @[i]layer]  [saycommand /showgui @[i]layer] $editingtex
-            ]
-        ]
-        guistrut 2
-        guilist [
-            guitext (tabify "background:" 3)
-            guibutton "colour" [pickcolour skybgcolour] [] $editingtex $skybgcolour
-            guistrut 1
-            guicheckbox "glare" skybgglare
-            guistrut 1
-            guitext "^fa(when skyboxes are transparent or absent)"
-        ]
-        guilist [
-            guitext (tabify "fog:" 3)
-            guibutton "colour" [pickcolour fogcolour] [] $editingtex $fogcolour
-            guistrut 1
-            guitext "distance "
-            guifield fog 6
-            guispring 1
-        ]
-
         guitab lighting
         guilist [
             guitext "Lighting uses precomputed lightmaps"
@@ -530,20 +445,20 @@
         ]
         guilist [ 
             guitext "^faambient lighting "
-            guitext "colour" "" $ambient
             guispring 1
+            guitext "colour   " "" $ambient
             guibutton "pick" [pickcolour ambient] [] $editingtex 
         ]
         guilist [ 
             guitext "^fashadowmap ambient "
-            guitext "colour" "" $shadowmapambient
             guispring 1
+            guitext "colour   " "" $shadowmapambient
             guibutton "pick" [pickcolour shadowmapambient] [] $editingtex
         ]
         guilist [ 
             guitext "^faskylight (vertical sunlight) "
-            guitext "colour" "" $skylight
             guispring 1
+            guitext "colour   " "" $skylight
             guibutton "pick" [pickcolour skylight] [] $editingtex 
         ]
         guistrut 0.5
@@ -561,6 +476,146 @@
         guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
         guieditbutton "save the map" [savemap]
 
+        guitab fog
+        guitext "customize background and fog colours"
+        guistrut 1
+        guilist [
+            guitext "fog: blends to full opacity at distance   "
+            guifield fog 8
+            guispring 1
+            guitext "colour   " "" $fogcolour
+            guibutton "pick" [pickcolour fogcolour] [] $editingtex
+        ]
+        guistrut 1
+        guilist [
+            guitext "sky background:"
+            guistrut 3
+            guicheckbox "glare" skybgglare
+            guispring 1
+            guitext "colour   " "" $skybgcolour
+            guibutton "pick" [pickcolour skybgcolour] [] $editingtex
+        ]
+        guitext "   shown when no skybox is present, useful for transparent skyboxes"
+        guistrut 1
+        guilist [
+            guitext "fog dome: blends depending on sky height"
+            guispring 1
+            guitext "colour   " "" $fogdomecolour
+            guibutton "pick" [pickcolour fogdomecolour] [] $editingtex
+        ]
+        guistrut 0.5
+        guilist [
+            guistrut 8
+            guifield fogdomeheight 6
+            guistrut 1
+            guitext "lower sky height for a max blend value of"
+            guispring 1
+            guifield fogdomemax 6
+        ]
+        guistrut 0.5
+        guilist [
+            guistrut 8
+            guifield fogdomeclip 6
+            guistrut 1
+            guitext "upper sky height for a min blend value of"
+            guispring 1
+            guifield fogdomemin 6
+        ]
+        guistrut 0.5
+        guilist [
+            guistrut 8
+            guieditcheckbox "cap (close) the fog dome at the bottom" fogdomecap
+        ]
+        guistrut 1.5
+        guieditbutton "   edit fog and colour properties of water and lava materials" [showgui materials]
+
+        guitab sky
+        guitext "create a background scenery using skyboxes and cloud layers"
+        guistrut 1
+        if (concatword $skybox $cloudbox $cloudlayer $envlayer) [
+            guilist [
+                guispring 1
+                looplist j [colour blend spin yaw glare] [
+                    guitext (tabify $j 2)
+                ]
+            ]
+        ] [
+            guiright [guitext "pick a skybox a or layer to show more options"]
+        ]
+        guistrut 0.3
+        looplist i [sky cloud cloudlayer envlayer] [
+            b = "box"
+            if (< -1 (stringstr $i layer)) [b = ""]
+            guilist [
+                guibutton [@i@b] [showgui [@@i@@b]] [saycommand /showgui [@@i@@b]] $editingtex
+                guispring 1
+                if $[@i@b] [
+                    guibutton "pick" [pickcolour @@[i]colour] [] $editingtex $[@[i]colour]
+                    guistrut 2
+                    guifield [@[i]blend] 6
+                    guistrut 1
+                    looplist j [spin yaw] [
+                        // one exception: spin/yawclouds, not cloud
+                        if (=s $i cloud) [
+                            guifield [@[j]clouds] 6
+                        ] [
+                            guifield [@j@i] 6
+                        ]
+                        guistrut 1
+                    ]
+                    guicheckbox " " [@[i]glare] 
+                    guistrut 3.5
+                    guiimage $guiexittex [[@@i@@b] ""] 0.5
+                ] [
+                    guistrut 1.25 1
+                ]
+            ]
+        ]
+        guistrut 1
+        if (concatword $cloudlayer $envlayer) [
+            guilist [
+                guispring 1
+                looplist j [fade height scrollx scrolly scale subdiv] [ // offset is not interesting, is it?
+                    guitext (tabify $j 2)
+                ]
+            ]
+        ] [
+            guiright [guitext "pick a cloud or env layer to show more options"]
+        ]
+        guistrut 0.3
+        looplist i [cloud env] [ 
+            guilist [
+                guibutton [@[i]layer] [showgui @[i]layer]  [saycommand /showgui @[i]layer] $editingtex
+                guispring 1
+                if $[@[i]layer] [
+                    looplist j [fade height scrollx scrolly scale subdiv] [
+                        guifield [@i@j] 6
+                        guistrut 1
+                    ]
+                ] [
+                    guistrut 1.25 1
+                ]
+            ]
+        ]
+        guistrut 1
+        guibutton "^fyreset all^fw skybox and layer variables, but keep the textures" [
+            looplist i [sky cloud envlayer cloudlayer] [ 
+                looplist j [colour blend glare] [
+                    do [@i@j (getvardef @i@j)]
+                ]
+            ]
+            looplist i [spin yaw] [
+                looplist j [sky clouds cloudlayer envlayer] [ 
+                    do [@i@j (getvardef @i@j)]
+                ]
+            ]
+            looplist i [cloud env] [ 
+                looplist j [fade height scrollx scrolly scale subdiv] [
+                    do [@i@j (getvardef @i@j)]
+                ]
+            ]
+        ]
+
         guitab grass
         guicenter [guitext "pick a grass type to apply on all surfaces with"]
         guicenter [guitext "the same texture as the current selection"]
@@ -568,7 +623,7 @@
         guilist [
             guilist [
                 guieditbutton "clear grass" [setgrass ""]
-                looplist i [
+                guilistsplit i 2 [
                     textures/grass
                     nobiax/grass01
                     nobiax/grass02
@@ -580,15 +635,19 @@
                     luckystrike/grass_lucky_green
                 ] [
                     //guiimage $i ... non-square images are not aligned correctly atm
-                    guieditbutton $i  [setgrass @i] 
+                    guifont huge [guieditbutton (format "^f(%1)" $i)  [setgrass @i] ]
+                    guistrut 0.2
                 ]
             ]
             guispring 1
             guilist [
+                guistrut 22 1
                 guilist [
                     grasshex = (hexcolour $grasscolour)
                     guifield grasshex 8 [grasscolour @grasshex]
-                    guibutton "scale colour" [pickcolour grasscolour] [] $editingtex
+                    guibutton "pick" [pickcolour grasscolour] [] $editingtex
+                    guispring 1
+                    guitext "colour"
                 ]
                 guilist [
                     guifield grassblend 8
@@ -620,6 +679,7 @@
         guistrut 1
         guicenter [guibutton "Tip: Looks better with texture blending" [showgui textures 6]]
 
+        // a tab from the classic editing menus - 
         guitab preset
         guitext         "    quick global lighting:"
         guitext " "
@@ -857,7 +917,7 @@
             guieditbutton "apply" [valpha $vara $vara2]
         ]
 
-        guitab vcolour
+        guitab colour
         if (= $guipasses 0) [hex = 0xffffff]
         guistrut 1
         guicenter [ guitext "pick a colour to scale the red, green and blue component of the texture" ]

--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -431,9 +431,13 @@
         guiright [guitext "^fathis affects file size and calculation time"]
         guistrut 0.5
         guilist [ 
+            guifield lightlod 4
+            guistrut 1
+            guitext "^falight lod"
+            guispring 1
             guifield lighterror 4
             guistrut 1
-            guitext "^falight error"
+            guitext "^faerror"
             guispring 1
             guifield lightcompress 4
             guistrut 1
@@ -441,8 +445,9 @@
             guispring 1
             guifield blurlms 4
             guistrut 1
-            guitext "^fablurr (soften)"
+            guitext "^fablurr"
         ]
+        guistrut 0.5
         guilist [ 
             guitext "^faambient lighting "
             guispring 1


### PR DESCRIPTION
move fog and background colour to its own tab, add detailed fogdome vars 
add some nice previews in the grass tab
fix line spacing in sky tab when enabling/removing layers or boxes
add a reset button for skybox/cloudlayer options, keeps the chosen sky textures
detail: vcolour --> colour in texture menu