### PR TITLE
enhance editing menus

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -1,4 +1,4 @@
-     
+
     // button for editing commands with built-in
     // key display, tooltip and r-click for console
     guieditbutton = [ 
@@ -260,6 +260,7 @@
                 guieditbutton lock [mastermode 2]
                 guispring 1
             ]
+            guitext (format "current master mode: %1" (getmastermode 1))
             guistrut 0.5
             guilist [
                 guispring 1
@@ -362,21 +363,25 @@
         guistrut 1
         guieditbutton "create texture variations" [showgui textures]
         guieditbutton "create a blendmap" [showgui textures 6] 
-        guistrut 3
-        guicenter [guitext "lighting and texturing are closely related"]
         guistrut 1
-        guieditbutton "lightmap options" [showgui world 3]
+        guicenter [guitext "apply lighting to the textured geometry"]
+        guistrut 1
         guieditbutton "create some light entities" [showgui lights]
         guieditbutton "optimize the geometry" remip
         guieditbutton "patch existing lightmap" [fullbright 0; patchlight]
         guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
         guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
+        guitext "^falight precision - larger means coarser and faster:"
+        guislider lightprecision 1 256 [] 0 1 (case (div $lightprecision 32) 0 [ result 0xff0000 ] 1 [ result 0xff6000 ] 2 [
+            result 0xffa000 ] 3 [ result 0xffff00 ] 4 [ result 0x80ff00 ] 5 [ result 0x00ff00 ] () [ result 0x008000 ])
+        guistrut 0.5
+        guieditbutton "advanced lightmap options" [showgui world 2]
     ] ]
 
     newgui world [ guistayopen [
         if (= 0 $guipasses) [coastval = 1.0]
         guistatus "some buttons have tooltips and alt-actions for console commands"
-        guitext "world variables control the map specific environment"
+        guicenter [guitext "world variables control the map specific environment"]
         guistrut 1
         guieditbutton "apply and customize material volumes" [showgui materials] 
         guibutton "advanced search for world ^fgvariables" [sleep 500 [varflags = 8; vartypes = 7; varsmore = 1]; showgui vars]
@@ -418,71 +423,65 @@
         guistrut 0.5
 
         guitab lighting
-        guilist [
-            guitext "Lighting uses precomputed lightmaps"
-            guispring 1
-            guieditbutton "create light entities" [showgui lights]
-        ]
-        guilist [ 
-            guifield lightprecision 4
-            guistrut 1
-            guitext "^falight precision - small values are expensive"
-        ]
-        guiright [guitext "^fathis affects file size and calculation time"]
+        guicenter [guitext "Lighting uses precomputed lightmaps"]
+        guitext "^falight precision" 
+        guislider lightprecision 1 256 [] 0 1 (case (div $lightprecision 32) 0 [ result 0xff0000 ] 1 [ result 0xff6000 ] 2 [
+            result 0xffa000 ] 3 [ result 0xffff00 ] 4 [ result 0x80ff00 ] 5 [ result 0x00ff00 ] () [ result 0x008000 ])
+        guitext "^falarger values imply coarser lighting, smaller mpz files, faster calculations"
         guistrut 0.5
+        guieditbutton "create light entities" [showgui lights]
+        guieditbutton "patch existing lightmap " [fullbright 0; patchlight]
+        guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
+        guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
+        guistrut 1
+        //guilist [ 
+        //    guitext "^fascale all lightmaps with a master colour (0 = none)"
+        //    guispring 1
+        //    guitext "colour   " "" $lightmapcolour
+        //    guibutton "pick" [pickcolour lightmapcolour] [] $editingtex 
+        //]
         guilist [ 
-            guifield lightlod 4
-            guistrut 1
-            guitext "^falight lod"
-            guispring 1
-            guifield lighterror 4
-            guistrut 1
-            guitext "^faerror"
-            guispring 1
-            guifield lightcompress 4
-            guistrut 1
-            guitext "^facompression"
-            guispring 1
-            guifield blurlms 4
-            guistrut 1
-            guitext "^fablurr"
-        ]
-        guistrut 0.5
-        guilist [ 
-            guitext "^faambient lighting "
+            guitext "^faambient lighting - independent of light sources"
             guispring 1
             guitext "colour   " "" $ambient
             guibutton "pick" [pickcolour ambient] [] $editingtex 
         ]
         guilist [ 
-            guitext "^fashadowmap ambient "
+            guitext "^fashadowmap ambient for actor shadows"
             guispring 1
             guitext "colour   " "" $shadowmapambient
             guibutton "pick" [pickcolour shadowmapambient] [] $editingtex
         ]
         guilist [ 
-            guitext "^faskylight (vertical sunlight) "
+            guitext "^faskylight - an implied vertical sunlight"
             guispring 1
             guitext "colour   " "" $skylight
             guibutton "pick" [pickcolour skylight] [] $editingtex 
         ]
-        guistrut 0.5
+        guistrut 1
+        guitext "advanced lightmap options - use non-default values with caution:"
         guilist [ 
+            guifield lighterror 3
+            guistrut 1
+            guitext "^faerror"
             guispring 1
-            guicheckbox skytexture skytexture
+            guifield lightcompress 3
+            guistrut 1
+            guitext "^facompress"
             guispring 1
-            guicheckbox skytexturelight skytexturelight
+            guifield blurlms 3
+            guistrut 1
+            guitext "^fablurr"
             guispring 1
+            guifield lmaa 3
+            guistrut 1
+            guitext "^faanti-aliasing"
+            guispring 1
+            guibutton "^fyreset" [ looplist i [lighterror lightcompress blurlms lmaa] [do [@i (getvardef @i)]]]
         ]
-        guistrut 0.5
-        guieditbutton "optimize geometry" "remip"
-        guieditbutton "patch existing lightmap " [fullbright 0; patchlight]
-        guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
-        guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
-        guieditbutton "save the map" [savemap]
 
         guitab fog
-        guitext "customize background and fog colours"
+        guicenter [guitext "customize background and fog colours"]
         guistrut 1
         guilist [
             guitext "fog: blends to full opacity at distance   "
@@ -494,16 +493,16 @@
         guistrut 1
         guilist [
             guitext "sky background:"
-            guistrut 3
-            guicheckbox "glare" skybgglare
             guispring 1
+            guicheckbox "glare" skybgglare
+            guistrut 6
             guitext "colour   " "" $skybgcolour
             guibutton "pick" [pickcolour skybgcolour] [] $editingtex
         ]
         guitext "   shown when no skybox is present, useful for transparent skyboxes"
-        guistrut 1
+        guistrut 1.5
         guilist [
-            guitext "fog dome: blends depending on sky height"
+            guitext "fog dome: a background colour gradient for the sky"
             guispring 1
             guitext "colour   " "" $fogdomecolour
             guibutton "pick" [pickcolour fogdomecolour] [] $editingtex
@@ -531,11 +530,11 @@
             guistrut 8
             guieditcheckbox "cap (close) the fog dome at the bottom" fogdomecap
         ]
-        guistrut 1.5
-        guieditbutton "   edit fog and colour properties of water and lava materials" [showgui materials]
+        guistrut 0.5
+        guieditbutton "edit fog and colour properties of water and lava materials" [showgui materials]
 
         guitab sky
-        guitext "create a background scenery using skyboxes and cloud layers"
+        guicenter [guitext "create a background scenery using skyboxes and cloud layers"]
         guistrut 1
         if (concatword $skybox $cloudbox $cloudlayer $envlayer) [
             guilist [
@@ -576,11 +575,11 @@
                 ]
             ]
         ]
-        guistrut 1
+        guistrut 0.7
         if (concatword $cloudlayer $envlayer) [
             guilist [
                 guispring 1
-                looplist j [fade height scrollx scrolly scale subdiv] [ // offset is not interesting, is it?
+                looplist j [fade height scrollx scrolly scale subdiv] [ // skipped: offset 
                     guitext (tabify $j 2)
                 ]
             ]
@@ -590,7 +589,7 @@
         guistrut 0.3
         looplist i [cloud env] [ 
             guilist [
-                guibutton [@[i]layer] [showgui @[i]layer]  [saycommand /showgui @[i]layer] $editingtex
+                guibutton $i [showgui @[i]layer]  [saycommand /showgui @[i]layer] $editingtex
                 guispring 1
                 if $[@[i]layer] [
                     looplist j [fade height scrollx scrolly scale subdiv] [
@@ -602,7 +601,17 @@
                 ]
             ]
         ]
-        guistrut 1
+        guistrut 0.5
+        guilist [
+            guitext "examples with quick sky lighting:"
+            guispring 1
+            guibutton "night" [ambient 40 40 40; skylight 70 80 90; skybox skyboxes/stars; skycolour 255 255 255; cloudlayer skyboxes/clouds01; cloudlayercolour 50 60 100; cloudlayerblend 0.3; cloudscrollx 0.005; fogcolour 12 10 13; fog 2000; calclight -1]
+            guispring 1
+            guibutton "morning" [ambient 60 35 40; skylight 170 140 145; skybox freezurbern/harmony; skycolour 255 160 180; cloudlayer skyboxes/clouds03; cloudlayercolour 255 125 170; cloudlayerblend 0.2; cloudscrollx 0.01; fogcolour 129 79 59; fog 2000; calclight -1]
+            guispring 1
+            guibutton "evening" [ambient 50 30 10; skylight 180 100 70; skybox skyboxes/sunsetflat; skycolour 255 255 255; cloudlayer skyboxes/clouds01; cloudlayercolour 255 100 50; cloudlayerblend 0.2; cloudscrollx 0.005; fogcolour 40 20 5; fog 2000; calclight -1]
+        ]
+        guistrut 0.5
         guibutton "^fyreset all^fw skybox and layer variables, but keep the textures" [
             looplist i [sky cloud envlayer cloudlayer] [ 
                 looplist j [colour blend glare] [
@@ -627,7 +636,6 @@
         guistrut 1
         guilist [
             guilist [
-                guieditbutton "clear grass" [setgrass ""]
                 guilistsplit i 2 [
                     textures/grass
                     nobiax/grass01
@@ -679,20 +687,65 @@
                     guispring 1
                     guitext "animscale"
                 ]
+                guiright [ guieditbutton "^fyclear" [setgrass ""]]
             ]
         ]
         guistrut 1
         guicenter [guibutton "Tip: Looks better with texture blending" [showgui textures 6]]
 
-        // a tab from the classic editing menus - 
-        guitab preset
-        guitext         "    quick global lighting:"
-        guitext " "
-        guibutton      "    night"                              [ambient 40 40 40; skylight 70 80 90; skybox skyboxes/stars; skycolour 255 255 255; cloudlayer skyboxes/clouds01; cloudlayercolour 50 60 100; cloudlayerblend 0.3; cloudscrollx 0.005; fogcolour 12 10 13; fog 2000; calclight -1]
-        guibutton      "    morning"                           [ambient 60 35 40; skylight 170 140 145; skybox freezurbern/harmony; skycolour 255 160 180; cloudlayer skyboxes/clouds03; cloudlayercolour 255 125 170; cloudlayerblend 0.2; cloudscrollx 0.01; fogcolour 129 79 59; fog 2000; calclight -1]
-        guibutton      "    evening"                           [ambient 50 30 10; skylight 180 100 70; skybox skyboxes/sunsetflat; skycolour 255 255 255; cloudlayer skyboxes/clouds01; cloudlayercolour 255 100 50; cloudlayerblend 0.2; cloudscrollx 0.005; fogcolour 40 20 5; fog 2000; calclight -1]
-        guistrut 2
-        guicenter [guitext "Note: This tab will be expanded later."]
+        guitab misc
+        guicenter [guitext "edit various world settings"]
+        guistrut 2 
+        guilist [
+            guilist [
+                guilist [
+                    guitext "minimap settings: "
+                    guispring 1
+                    guieditbutton "^fgrefresh" [minimapsize @minimapsize]
+                ]
+                guilist [ 
+                    guitext "^fabackground"
+                    guistrut 1
+                    guitext "colour   " "" $minimapcolour
+                    guibutton "pick" [pickcolour minimapcolour] [] $editingtex
+                ]
+                guilist [ 
+                    guitext "^fadrawn at height"
+                    guistrut 1
+                    guifield minimapheight 8
+                    guispring 1
+                ]
+                guibutton "set height to current position" [minimapheight (at $getcampos 2)]
+                guistrut 0.2
+                guicheckbox "minimap clip" minimapclip
+            ]
+            guispring 1
+            guilist [ 
+                guitext "^fasky texture:"
+                guicheckbox "apply sunlight" skytexturelight
+                guicheckbox "make invisible" skytexture 0 1 [if $skytexture [
+                    echo skytexture 1: skybox
+                ] [
+                    echo skytexture 0: invisible - takes affect after saving and loading]
+                ]
+            ]
+            guistrut 1
+            guinohitfx [guiimage textures/sky [] 2]
+            guistrut 1 
+        ]
+        guistrut 1
+        guilist [
+            guilist [
+                guitext "point aliases"
+                guinohitfx [guiimage $pointtex [] 2.5]
+            ]
+            guistrut 2
+            guilist [
+                guilistsplit i 2 [1 2 3 4 5 6 7 8] [
+                    do [guifield point_@i -20]
+                ]
+            ]
+        ]
     ] ]
 
     newgui resetworldvars [
@@ -1089,6 +1142,7 @@
     ]
     efuireset
     
+    groupedit = 0
     newgui ents [
         guistatus "Please note the selection info at the right side of the screen" 
         guistayopen [
@@ -1137,8 +1191,9 @@
             ]
 
             guitab edit
-            guicenter [
-                if (= 0 (enthavesel)) [
+            if (= 0 (enthavesel)) [
+                groupedit = 0
+                guicenter [
                     slider = 0
                     guilist [
                         guistrut 2 
@@ -1153,119 +1208,125 @@
                         guieditbutton "select all entities on this map" [entfind]
                     ]
                 ]
-                if (= 1 (enthavesel)) [
+            ]
+            if (> (enthavesel) 1) [
+                if $groupedit [
+                    guistrut 1
+                ] [
+                    guitext (format "selected entities: %1" $enthavesel)
+                    guieditbutton "cycle entity links  ->  <-  <-->  -" [entlink]
                     guilist [
-                        guibutton "reselect matching ents (find)" [entfind @efuitypename @efuiattrs] [] 
-                        guilist [
-                            guitext "deselect:"
-                            guispring 1
-                            guieditbutton2 "ents" [entcancel] [] 
-                            guispring 1
-                            guieditbutton2 "all" [cancelsel] [] 
-                        ]
-                        guistrut 1
-                        itype = (indexof $enttypelist (enttype))
-                        guitext (format "selected: %1 (index %2)" (enttype) (entindex))
-                        loop iattr (getentattr $itype) [
-                            a = (getentattr $itype $iattr (entattr 0)) 
-                            if (|| (stringlen $a) (= $iattr 0)) [
-                                guilist [
-                                    guifont emphasis [
-                                    guibutton "+" [entprop @iattr 1]
-                                    guistrut 1
-                                    guibutton "-" [entprop @iattr -1]
-                                    guistrut 1
-                                    ]
-                                    field@iattr = (entattr $iattr)
-                                    guifield field@iattr -10 [entattr @iattr (field@iattr)]
-                                    guistrut 1
-                                    guitext $a
-                                    guispring 1
-                                    if (=s $a yaw) [
-                                        guibutton pick [pickattr = @iattr; showcompass entyaw] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (=s $a pitch) [
-                                        guibutton pick [pickattr = @iattr; showcompass entpitch] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (=s $a modes) [
-                                        guibutton pick [pickattr = @iattr; showgui entmodes] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (=s $a muts) [
-                                        guibutton pick [pickattr = @iattr; showgui entmuts] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (=s $a colour) [
-                                        guibutton pick [pickattr = @iattr; showgui entcolour] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (=s $a dir) [
-                                        guibutton pick [showgui particledir] -1 $editingtex
-                                        guistrut 1
-                                    ]
-                                    if (< $iattr 12) [
-                                        guitext (dobindsearch (concat domodifier (+ 11 $iattr)) edit)
-                                    ]
-                                ]    
-                            ]    
-                        ]
-                        guistrut 1
-                        guieditbutton "edit selected ents via console" selentedit
-                        guilist [
-                            guitext "quick-edit: mousewheel and "
-                            guitext (dobindsearch [domodifier 11] edit)
-                            guitext (dobindsearch [domodifier 12] edit)
-                            guitext (dobindsearch [domodifier 13] edit)
-                            guitext " etc."
-                        ]
+                        guitext "^faview:"
+                        guispring 1
+                        guieditbutton "next ent" [entautoview 1] 
+                        guispring 1
+                        guieditbutton "previous ent" [entautoview -1] 
+                        guispring 1
+                        guitext (dobindsearch [domodifier 10; onrelease entautoview] edit)
                     ]
-                ] 
-                if (< 1 (enthavesel)) [
+                    guistrut 1
+                    guitext "click below to select and edit an entity"
+                    guistrut 1
+                ]
+                entgetlist = ""
+                entindexlist = ""
+                imax = 0
+                entloop [
+                    append entindexlist (entindex)
+                    append entgetlist (format "[(%1)^t %2]" (entindex) (entget))
+                    imax = (+ $imax 1) 
+                ]
+                slidermax = (max (- $imax 15) 0)
+                guilist [
                     guilist [
-                        guitext (format "selected entities: %1" $enthavesel)
-                        guieditbutton "cycle entity links  ->  <-  <-->  -" [entlink]
-                        guilist [
-                            guitext "^faview:"
-                            guispring 1
-                            guieditbutton "next ent" [entautoview 1] 
-                            guispring 1
-                            guieditbutton "previous ent" [entautoview -1] 
-                            guispring 1
-                            guitext (dobindsearch [domodifier 10; onrelease entautoview] edit)
-                        ]
-                        guistrut 1
-                        guitext "click below to select and edit an entity"
-                        guistrut 1
-                        entgetlist = ""
-                        entindexlist = ""
-                        imax = 0
-                        entloop [
-                            append entindexlist (entindex)
-                            append entgetlist (format "[(%1)^t %2]" (entindex) (entget))
-                            imax = (+ $imax 1) 
-                        ]
-                        slidermax = (max (- $imax 15) 0)
-                        guilist [
+                        guistrut 30 1
+                        loop i (min 15 $imax) [
+                            j = (+ $i $slider)
                             guilist [
-                                guistrut 30 1
-                                loop i (min 15 $imax) [
-                                    j = (+ $i $slider)
-                                    guilist [
-                                        guibutton (at $entgetlist $j) [
-                                            entcancel
-                                            entselect [(= (at $entindexlist @@j) (entindex))]
-                                            slider = 0
-                                        ]
-                                    ]
+                                guibutton (at $entgetlist $j) [
+                                    entcancel
+                                    entselect [(= (at $entindexlist @@j) (entindex))]
+                                    slider = 0
                                 ]
                             ]
-                            if (slidermax) [guislider slider 0 $slidermax [] 1 1]
                         ]
+                    ]
+                    if (slidermax) [guislider slider 0 $slidermax [] 1 1]
+                ]
+                guistrut 1
+                guicheckbox (format "^f%1 edit multiple ents: use with caution!" (? $groupedit zyw d)) groupedit 
+            ]    
+            if (|| $groupedit (= 1 (enthavesel))) [
+                if (> $enthavesel 1) [
+                    guitext "Warning: entity attributes may differ" $waitingtex
+                ] [
+                    guibutton "reselect matching ents (find)" [entfind @efuitypename @efuiattrs] [] 
+                    guilist [
+                        guitext "deselect:"
+                        guispring 1
+                        guieditbutton2 "ents" [entcancel] [] 
+                        guispring 1
+                        guieditbutton2 "all" [cancelsel] [] 
+                    ]
+                ]
+                guistrut 1
+                itype = (indexof $enttypelist (enttype))
+                guitext (format "selected: %1 (index %2)" (enttype) (entindex))
+                loop iattr (getentattr $itype) [
+                    a = (getentattr $itype $iattr (entattr 0)) 
+                    if (|| (stringlen $a) (= $iattr 0)) [
+                        guilist [
+                            guifont emphasis [
+                            guibutton "+" [entprop @iattr 1]
+                            guistrut 1
+                            guibutton "-" [entprop @iattr -1]
+                            guistrut 1
+                            ]
+                            field@iattr = (entattr $iattr)
+                            guifield field@iattr -10 [entattr @iattr (field@iattr)]
+                            guistrut 1
+                            guitext $a
+                            guispring 1
+                            if (=s $a yaw) [
+                                guibutton pick [pickattr = @iattr; showcompass entyaw] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a pitch) [
+                                guibutton pick [pickattr = @iattr; showcompass entpitch] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a modes) [
+                                guibutton pick [pickattr = @iattr; showgui entmodes] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a muts) [
+                                guibutton pick [pickattr = @iattr; showgui entmuts] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a colour) [
+                                guibutton pick [pickattr = @iattr; showgui entcolour] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a dir) [
+                                guibutton pick [showgui particledir] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (< $iattr 12) [
+                                guitext (dobindsearch (concat domodifier (+ 11 $iattr)) edit)
+                            ]
+                        ]    
                     ]    
-                ]    
-            ]
+                ]
+                guistrut 1
+                guieditbutton "edit selected ents via console" selentedit
+                guilist [
+                    guitext "quick-edit: mousewheel and "
+                    guitext (dobindsearch [domodifier 11] edit)
+                    guitext (dobindsearch [domodifier 12] edit)
+                    guitext (dobindsearch [domodifier 13] edit)
+                    guitext " etc."
+                ]
+            ] 
 
             guitab "find"
             guicenter [guitext "advanced search and replacement"]


### PR DESCRIPTION
allow entity group edit again via ents menu, edit tab
tweak world edit menu layout
remove preset tab, put the examples on a single line in the sky tab
add a slider (with variable colour) for light precision in world and geometry menus
revamp lighting tab in world menu, add a reset button for advanced options
add misc tab to world menu: minimap options, skytexture light/visibility, point aliases 
show mastermode in editlock menu