### PR TITLE
tweak/fix vars menu

### DIFF
--- a/config/menus/vars.cfg
+++ b/config/menus/vars.cfg
@@ -20,13 +20,24 @@ newgui vars [
     guilist [
         guistrut 1
         guifield varsearchstrval 32 [varsearchstr = $varsearchstrval; varnum = -1; varindex = 0] -1 0 "" 0 "^fd<enter search terms>" 1
-        guistrut 3
+        guistrut 2
         guilist [
             guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
             guistrut 0.15
             guilist [
                 guistrut 1
                 guitext (format "^fg%1 ^fa%2 found" $numvars (? (= $numvars 1) "match" "matches"))
+                guistrut 1
+            ]
+            guistrut 0.15
+        ]
+        guistrut 3
+        guilist [
+            guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
+            guistrut 0.15
+            guilist [
+                guistrut 1
+                guistayopen [guibutton "export" [saycommand /writevars ""]]
                 guistrut 1
             ]
             guistrut 0.15
@@ -137,20 +148,18 @@ newgui vars [
                         guitext "^fa???"
                     ]
                 ]
-                if (= $scurvartype 2) [
+                if (|| (= $scurvartype 2) (= $scurvartype 4))  [
                     guistrut 0.25
                     guilist [
-                        guitext "^fadefault"
-                        guispring 1
-                        guieditor [@[scurvar]_vardef] (? $varsmore -43 -58) 8 4 -1 0 "" (getsvardef $scurvar 1)
+                        guitext (tabify "^fadefault:" 2)
+                        guieditor [@[scurvar]_vardef] (? $varsmore -43 -58) 0 4 -1 0 "" (getsvardef $scurvar 1)
                     ]
                 ]
                 guistrut 0.25
                 if (> $scurvartype 2) [
-                    guistrut (? $varsmore 50 65) 1
+                    guistrut (? $varsmore 52 67) 1
                     guilist [
-                        guitext "^faconsole"
-                        guistrut 1
+                        guitext (tabify "^faconsole" 2)
                         guilist [
                             guibackground $guifieldbgcolour $guifieldbgblend $guifieldbordercolour $guifieldborderblend 1
                             guistrut  0.2
@@ -192,11 +201,17 @@ newgui vars [
                         guistrut 0.5
                         guibutton "pick a colour" [showgui pickcolour] [] $editingtex
                     ] [ 
-                        guilist [
-                            guitext "value:"
-                            guistrut 1
-                            [@[scurvar]_varval] = $$scurvar
-                            guifield [@[scurvar]_varval] (? $varsmore -43 -58) [@scurvar $[@@[scurvar]_varval]] -1 0 ""
+                        if (&& (= $scurvartype 2) (> (stringlen $$scurvar) 500)) [
+                            guilist [
+                                guitext (tabify "value:" 2)
+                                guistayopen [ guibutton "set via console" [saycommand (format "/%1 %2" $scurvar $$scurvar)] [] "textures/menu" ]
+                            ]
+                        ] [
+                            guilist [
+                                guitext (tabify "value:" 2 )
+                                [@[scurvar]_varval] = $$scurvar
+                                guifield [@[scurvar]_varval] (? $varsmore -43 -58) [@scurvar $[@@[scurvar]_varval]] -1 0 "" 
+                            ]
                         ]
                     ]    
                     if (& (= (getvartype $scurvar) 0) (< (getvarmax $scurvar) (<< 1 20))) [
@@ -214,22 +229,20 @@ newgui vars [
                 if (stringlen $scurusage) [
                     guistrut 0.25
                     guilist [
-                        guitext "^fausage:"
-                        guistrut 1
-                        guitext (concat $scurvar $scurusage) "" -1 -1 3000
+                        guitext (tabify "^fausage:" 2)
+                        guitext (concat $scurvar $scurusage) "" -1 -1 2800
                     ]
                 ]
                 scurdesc = (getvardesc $scurvar)
                 if (stringlen $scurdesc) [
                     guistrut 0.25
                     guilist [
-                        guitext "^fainfo:"
-                        guistrut 1
-                        guitext $scurdesc "" -1 -1 3000
+                        guitext (tabify "^fainfo:" 2)
+                        guitext $scurdesc "" -1 -1 2800
                     ]
                 ]
             ] [
-                guistrut (? $varsmore 50 65) 1
+                guistrut (? $varsmore 52 67) 1
                 guifont "emphasis" [ guitext "no variable or command selected" ]
                 guifont "little" [
                     guitext "^fause the list on the left to pick a variable" point


### PR DESCRIPTION
some tweaks before #326 gets fixed, thereafter we can use fields/ default boxes of fixed height again
i.e fix display of string defaults
display default content of aliases, too
align the layout using tabify on keywords to the left
use console to set strings if they are long enough to mess up the layout (for now)
add a button for writevars