### PR TITLE
tweak editing menus

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -30,10 +30,10 @@
         guifont emphasis [
             // guicenter [guieditbutton2 [toggle edit mode] [edittoggle]]
             guicenter [guibutton (format "texture list %1" (dobindsearch showtexgui edit)) [cleargui ; showtexgui ]]
+            guicenter [guibutton "geometry and texturing" [showgui geometry]]
             guicenter [guibutton "map info and waypoints" [showgui mapinfo]]
             guicenter [guibutton "editing options" [showgui editoptions]]
-            guicenter [guibutton "geometry and prefabs" [showgui geometry]]
-            guicenter [guibutton "world variables and lighting" [showgui world]]
+            guicenter [guibutton "environment settings" [showgui world]]
             guicenter [guibutton "texture variations" [showgui textures]]
             guicenter [guibutton "find and edit entities" [showgui ents]]
             guicenter [guibutton "configure key binds" [sleep 50 [curbindtype = 2]; showgui options_controls]]
@@ -45,10 +45,10 @@
     newcompass editing $editingtex [
         //compass "^fs^fcQ^fSuit editing" Q [edittoggle]
         compass "^fs^fct^fSexture list" T [showtexgui]
-        compass "map, waypoints and ^fs^fcr^fSoutes" R [showgui mapinfo]
+        compass "^fs^fcg^fSeometry and texturing" G [showgui geometry]
+        compass "map info and ^fs^fcr^fSoutes" R [showgui mapinfo]
         compass "e^fs^fcd^fSiting options" D [showgui editoptions]
-        compass "^fs^fcg^fSeometry and prefabs" G [showgui geometry]
-        compass "^fs^fcw^fSorld and lighting" W [showgui world]
+        compass "^fs^fcw^fSorld variables" W [showgui world]
         compass "texture ^fs^fcv^fSariations" V [showgui textures]
         compass "^fs^fcf^fSind and edit entities" F [showgui ents]
         compass "^fs^fcc^fSonfigure key binds" C [sleep 50 [curbindtype = 2]; showgui options_controls]
@@ -297,22 +297,21 @@
         guieditbutton "push / pull corners" [domodifier 3]
         guistrut 0.5
         guieditbutton "deselect" "cancelsel"
-        guieditbutton "deselect only ents" "entcancel"
         guistrut 0.5
         guieditbutton "delete selection (ents first)" editdel
         guieditbutton "copy" "editcopy"
         guieditbutton "paste" "editpaste"
-        guieditbutton "cut and paste on release" "editcut"
+        guieditbutton "^fdcut and paste on release" "editcut"
         guistrut 0.5
         guieditbutton "flip" "editflip"
-        guieditbutton "rotate via mouse wheel" [domodifier 4]
+        guieditbutton "^fdrotate via mouse wheel" [domodifier 4]
         guistrut 0.5
         guieditbutton "toggle heightmap mode" [hmapedit (! $hmapedit); blendpaintmode 0] 
-        guieditbutton "cycle heightmap brushes via mouse wheel" [domodifier 9]
+        guieditbutton "^fdcycle heightmap brushes via mouse wheel" [domodifier 9]
         guistrut 0.5
         guitext (format "copy/paste is scaled by the current grid size: %1" (<< 1 $gridpower))
-        guieditbutton "change via mouse wheel" [domodifier 1]
         guislider gridpower 0 (min (- $mapsize 1) 12) 
+        guieditbutton "^fdchange via mouse wheel" [domodifier 1]
 
         guitab "prefabs"
         if (= 0 $guipasses) [
@@ -357,10 +356,10 @@
                 guispring 1 
                 guibutton (dobindsearch showtexgui edit)
         ] [cleargui ; showtexgui ] [saycommand /showtexgui] [guitooltip showtexgui]    
-        guieditbutton "cycle textures via mouse wheel" [domodifier 6]
+        guieditbutton "^fdcycle textures via mouse wheel" [domodifier 6]
         guieditbutton "grab texture from selected face" gettex
         guieditbutton "repeat last texture change across the entire map" [allfaces 0; replace]
-        guistrut 1
+        guieditbutton "repeat last texture change inside selection" [allfaces 0; replaceinsel]
         guieditbutton "create texture variations" [showgui textures]
         guieditbutton "create a blendmap" [showgui textures 6] 
         guistrut 1
@@ -371,6 +370,7 @@
         guieditbutton "patch existing lightmap" [fullbright 0; patchlight]
         guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
         guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
+        guistrut 0.5
         guitext "^falight precision - larger means coarser and faster:"
         guislider lightprecision 1 256 [] 0 1 (case (div $lightprecision 32) 0 [ result 0xff0000 ] 1 [ result 0xff6000 ] 2 [
             result 0xffa000 ] 3 [ result 0xffff00 ] 4 [ result 0x80ff00 ] 5 [ result 0x00ff00 ] () [ result 0x008000 ])
@@ -419,6 +419,12 @@
             guifield liquidspeed 15
             guistrut 1
             guitext "liquid speed"
+            guispring 1
+            guibutton "^fyreset^fa these physics settings" [
+                looplist i [gravity floorcoast aircoast liquidcoast liquidspeed] [
+                    do [@i (getfvardef @i)]
+                ]
+            ]
         ]
         guistrut 0.5
 
@@ -428,56 +434,80 @@
         guislider lightprecision 1 256 [] 0 1 (case (div $lightprecision 32) 0 [ result 0xff0000 ] 1 [ result 0xff6000 ] 2 [
             result 0xffa000 ] 3 [ result 0xffff00 ] 4 [ result 0x80ff00 ] 5 [ result 0x00ff00 ] () [ result 0x008000 ])
         guitext "^falarger values imply coarser lighting, smaller mpz files, faster calculations"
-        guistrut 0.5
-        guieditbutton "create light entities" [showgui lights]
-        guieditbutton "patch existing lightmap " [fullbright 0; patchlight]
-        guieditbutton "quick lightmap calculation" [fullbright 0; calclight -1]
-        guieditbutton "full lightmap calculation" [fullbright 0; calclight 1]
-        guistrut 1
-        //guilist [ 
-        //    guitext "^fascale all lightmaps with a master colour (0 = none)"
-        //    guispring 1
-        //    guitext "colour   " "" $lightmapcolour
-        //    guibutton "pick" [pickcolour lightmapcolour] [] $editingtex 
-        //]
-        guilist [ 
-            guitext "^faambient lighting - independent of light sources"
+        guistrut 1.5
+        guilist [
+            guilist [
+                guieditbutton "create some light ents" [showgui lights]
+                guieditbutton "patch lightmap " [fullbright 0; patchlight]
+                guieditbutton "quick calculation" [fullbright 0; calclight -1]
+                guieditbutton "full calculation" [fullbright 0; calclight 1]
+                guistrut 1
+                guistrut 30 1
+                guitext "colours (0 = disabled)"
+                guilist [ 
+                    guitext "^fascale lightmap"
+                    guispring 1
+                    guitext "colour   " "" $lightmapcolour
+                    guibutton "pick" [pickcolour lightmapcolour] [] $editingtex 
+                ]
+                guilist [ 
+                    guitext "^faambient lighting"
+                    guispring 1
+                    guitext "colour   " "" $ambient
+                    guibutton "pick" [pickcolour ambient] [] $editingtex 
+                ]
+                guilist [ 
+                    guitext "^faactor shadows"
+                    guispring 1
+                    guitext "colour   " "" $shadowmapambient
+                    guibutton "pick" [pickcolour shadowmapambient] [] $editingtex
+                ]
+                guilist [ 
+                    guitext "^faimplied sunlight"
+                    guispring 1
+                    guitext "colour   " "" $skylight
+                    guibutton "pick" [pickcolour skylight] [] $editingtex 
+                ]
+            ]
             guispring 1
-            guitext "colour   " "" $ambient
-            guibutton "pick" [pickcolour ambient] [] $editingtex 
-        ]
-        guilist [ 
-            guitext "^fashadowmap ambient for actor shadows"
-            guispring 1
-            guitext "colour   " "" $shadowmapambient
-            guibutton "pick" [pickcolour shadowmapambient] [] $editingtex
-        ]
-        guilist [ 
-            guitext "^faskylight - an implied vertical sunlight"
-            guispring 1
-            guitext "colour   " "" $skylight
-            guibutton "pick" [pickcolour skylight] [] $editingtex 
-        ]
-        guistrut 1
-        guitext "advanced lightmap options - use non-default values with caution:"
-        guilist [ 
-            guifield lighterror 3
-            guistrut 1
-            guitext "^faerror"
-            guispring 1
-            guifield lightcompress 3
-            guistrut 1
-            guitext "^facompress"
-            guispring 1
-            guifield blurlms 3
-            guistrut 1
-            guitext "^fablurr"
-            guispring 1
-            guifield lmaa 3
-            guistrut 1
-            guitext "^faanti-aliasing"
-            guispring 1
-            guibutton "^fyreset" [ looplist i [lighterror lightcompress blurlms lmaa] [do [@i (getvardef @i)]]]
+            guilist [
+                guitext "^faadvanced options:"
+                guitext "^fause with caution"
+                guilist [ 
+                    guifield lightlod 3
+                    guistrut 0.3
+                    guitext "^falevel of detail"
+                ]
+                guilist [ 
+                    guifield lighterror 3
+                    guistrut 0.3
+                    guitext "^faerror"
+                ]
+                guilist [ 
+                    guifield lightcompress 3
+                    guistrut 0.3
+                    guitext "^facompress"
+                ]
+                guilist [ 
+                    guifield blurlms 3
+                    guistrut 0.3
+                    guitext "^fablurr"
+                ]
+                guilist [ 
+                    guifield lmaa 3
+                    guistrut 0.3
+                    guitext "^faanti-aliasing"
+                ]
+                guistrut 1
+                guilist [ 
+                    guibutton "^fyreset all" [
+                        looplist i [lightmapcolour ambient shadowmapambient skylight lighterror lightcompress blurlms lmaa] [
+                            do [@i (getvardef @i)]
+                        ]
+                    ]
+                ]
+            ]
+            guistrut 2
         ]
 
         guitab fog
@@ -651,16 +681,15 @@
                     guifont huge [guieditbutton (format "^f(%1)" $i)  [setgrass @i] ]
                     guistrut 0.2
                 ]
+                guieditbutton "^fyclear^fa from texture" [setgrass ""]
             ]
             guispring 1
             guilist [
                 guistrut 22 1
                 guilist [
-                    grasshex = (hexcolour $grasscolour)
-                    guifield grasshex 8 [grasscolour @grasshex]
-                    guibutton "pick" [pickcolour grasscolour] [] $editingtex
+                    guitext "colour" "" $grasscolour
                     guispring 1
-                    guitext "colour"
+                    guibutton "pick" [pickcolour grasscolour] [] $editingtex
                 ]
                 guilist [
                     guifield grassblend 8
@@ -687,7 +716,11 @@
                     guispring 1
                     guitext "animscale"
                 ]
-                guiright [ guieditbutton "^fyclear" [setgrass ""]]
+                guiright [ guibutton "^fyreset" [
+                    looplist i [colour blend height scale animmillis animscale] [
+                        do [grass@i (getfvardef grass@i)]
+                    ]
+                ] ]
             ]
         ]
         guistrut 1
@@ -910,7 +943,7 @@
         guistrut 0.5
         guicenter [guitext "v-commands create variations of the currently selected texture"]
         guicenter [
-            guieditbutton "reset variation on selected texture" [resettex]
+            guieditbutton "reset variation on selected texture" [vreset]
             guispring 1
             guibutton "^fyclear^fw unused textures"  [showgui texreset]
         ]
@@ -1214,6 +1247,13 @@
                     guistrut 1
                 ] [
                     guitext (format "selected entities: %1" $enthavesel)
+                    guilist [
+                        guitext "deselect:"
+                        guispring 1
+                        guieditbutton2 "ents" [entcancel] [] 
+                        guispring 1
+                        guieditbutton2 "all" [cancelsel] [] 
+                    ]
                     guieditbutton "cycle entity links  ->  <-  <-->  -" [entlink]
                     guilist [
                         guitext "^faview:"
@@ -1224,9 +1264,9 @@
                         guispring 1
                         guitext (dobindsearch [domodifier 10; onrelease entautoview] edit)
                     ]
-                    guistrut 1
+                    guistrut 0.5
                     guitext "click below to select and edit an entity"
-                    guistrut 1
+                    guistrut 0.5
                 ]
                 entgetlist = ""
                 entindexlist = ""
@@ -1771,3 +1811,4 @@
             ]
         ]
     ]
+


### PR DESCRIPTION
tweak edit compass / main menu 
rearrange lighting tab in world menu, more room for advanced options, don't forget lod
gray out "non-functional" buttons for looking up modifers etc.
fix vreset button in texture menu
add replaceinsel to texturing tab
add reset buttons for physics and grass options, tweak grass colour and "clear from texture"
remove entcancel from geomtry menu, show also in ent group selection