### PR TITLE
enhance editoptions and map info menus

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -29,9 +29,9 @@
     newgui edit [ guistayopen [
         guifont emphasis [
             // guicenter [guieditbutton2 [toggle edit mode] [edittoggle]]
-            guicenter [guibutton (format "texture list %1" (dobindsearch showtexgui edit)) [cleargui ; showtexgui ]]
+            guicenter [guibutton "map info" [showgui mapinfo]]
             guicenter [guibutton "geometry and texturing" [showgui geometry]]
-            guicenter [guibutton "map info and waypoints" [showgui mapinfo]]
+            guicenter [guibutton (format "texture list %1" (dobindsearch showtexgui edit)) [cleargui ; showtexgui ]]
             guicenter [guibutton "editing options" [showgui editoptions]]
             guicenter [guibutton "environment settings" [showgui world]]
             guicenter [guibutton "texture variations" [showgui textures]]
@@ -44,9 +44,9 @@
     // this one could go to config/compass.cfg, but it is convenient to have it here for comparison
     newcompass editing $editingtex [
         //compass "^fs^fcQ^fSuit editing" Q [edittoggle]
-        compass "^fs^fct^fSexture list" T [showtexgui]
+        compass "m^fs^fca^fSp info" A [showgui mapinfo]
         compass "^fs^fcg^fSeometry and texturing" G [showgui geometry]
-        compass "map info and ^fs^fcr^fSoutes" R [showgui mapinfo]
+        compass "^fs^fct^fSexture list" T [showtexgui]
         compass "e^fs^fcd^fSiting options" D [showgui editoptions]
         compass "^fs^fcw^fSorld variables" W [showgui world]
         compass "texture ^fs^fcv^fSariations" V [showgui textures]
@@ -85,20 +85,27 @@
                     guibutton "pick" [showgui music]
                 ]
                 guilist [
-                    guifield numplayers -20
+                    guifield numplayers 4
+                    guitext " num"
                     guistrut 2
+                    guifield maxplayers 4
+                    guitext " max"
+                    guistrut 2.2
                     guitext  "players"
                 ]
+                guistrut 0.5
                 guilist [
-                    guifield maxplayers -20
-                    guistrut 2
-                    guitext  "max players"
+                    guitext "switch teams at half-time:"
+                    guispring 1
+                    guiradio "off" mapbalance 0
                 ]
                 guilist [
-                        guifield mapbalance -20
-                    guistrut 2
-                    guieditcheckbox "asymmetric map" mapbalance
+                    guispring 1
+                    guiradio "in ctf, dnc and bb" mapbalance 1
+                    guispring 1
+                    guiradio "in all modes" mapbalance 2
                 ]
+                guistrut 0.5
                 guilist [
                     guitext (format "map revision: %1" $maprevision)
                     guispring 1
@@ -112,14 +119,11 @@
                 guilist [
                     guitext (format "map size (power): %1" $mapsize)
                     guispring 1
-                    guieditbutton2 "shrink where empty" [shrinkmap]
+                    guieditbutton2 "cull empty space" [shrinkmap]
                 ]
                 guitext (format "map file format version: %1" $mapversion)
                 guistrut 0.5
-                if (isonline) [
-                        guieditbutton "refresh map from server" getmap
-                        guieditbutton "send map to server" sendmap
-                ]
+                if (isonline) [ guieditbutton "refresh map from server" getmap ]
                 guibutton "edit the config file" [notepad @mapname.cfg] []
                 guibutton "reset the texture list" [showgui texreset] [] $warningtex
             ]
@@ -191,6 +195,72 @@
                 guistrut 0.5
             ]
         ]
+
+        guitab load
+        local [maps whichmaps]
+        if (= 0 $guipasses) [
+            whichmaps = 0
+            selmap = $mapname
+            slider = 0
+            maps = $mapname
+            imax = 1
+        ]
+        guitext "pick a map and click the preview image to start a new editing session"
+        guistrut 2
+        guilist [
+            guilist [
+                guitext "browse maps:"
+                guistrut 0.5
+                guiradio "current map" whichmaps 0 [slider = 0; maps = "" ; selmap = $mapname;]
+                guiradio "custom maps" whichmaps 1 [
+                    slider = 0
+                    maps = ""
+                    imax = 0
+                    loopfiles i "maps" mpz [
+                        append maps $i
+                    ]
+                    maps = (listdel $maps $mainmaps)
+                    maps = (listdel $maps $racemaps)
+                    maps = (stringreplace [ @maps] " " " maps/")
+                ] 
+                guiradio "main maps" whichmaps 2 [slider = 0; maps = (stringreplace [ @mainmaps] " " " maps/")]
+                guiradio "race maps" whichmaps 3 [slider = 0; maps = (stringreplace [ @racemaps] " " " maps/")]
+                guiradio "small maps" whichmaps 4 [slider = 0; maps = (stringreplace [ @smallmaps] " " " maps/")]
+                guiradio "medium maps" whichmaps 5 [slider = 0; maps = (stringreplace [ @mediummaps] " " " maps/")]
+                guiradio "large maps" whichmaps 6 [slider = 0; maps = (stringreplace [ @largemaps] " " " maps/")]
+                guiradio "temp maps" whichmaps 7 [
+                    slider = 0
+                    maps = ""
+                    loopfiles i "temp/maps" mpz [
+                        append maps [temp/maps/@i]
+                    ]
+                ] 
+            ] 
+            guispring 1
+            imax = (listlen $maps)
+            if (imax) [
+                slidermax = (max (- $imax 15) 0)
+                guilist [
+                    guistrut 30 1
+                    loop i (min 15 $imax) [
+                        j = (+ $i $slider)
+                        p = (at $maps $j)
+                        guibutton $p [selmap = @p] 
+                    ]
+                ]
+                if (slidermax) [guislider slider 0 $slidermax [] 1 1] [guistrut 3 ]
+            ] [
+                guistrut 33 
+            ]
+            guispring 1
+            guilist [
+                guicenter [guiimage [@selmap] [edit @selmap] 5 1 $emblemtex]
+                guicenter [guitext $selmap]
+                guistrut 0.5
+                guicenter [guitext "^fyWARNING:"]
+                guicenter [guitext "unsaved changes are lost"]
+            ]
+        ]
     ] ]
 
     newgui music [ guistayopen [
@@ -216,21 +286,18 @@
         guistatus "some buttons have tooltips and alt-actions for console commands"
         guilist [
             guilist [
-                guieditcheckbox "toggle edit radar" showeditradar
                 guieditcheckbox "show material volumes" showmat
-                guistrut 0.5
-                guieditcheckbox "toggle fullbright" "fullbright"
-                guieditcheckbox "toggle wireframe" "wireframe"
-                guieditcheckbox "toggle blank geometry" "blankgeom"
-                guieditcheckbox "toggle outline" "outline"
-                guibutton "change outline colour" [pickcolour outlinecolour] [] $editingtex
-                guistrut 0.5
-                guieditcheckbox "toggle paste grid" "showpastegrid"
-                guieditcheckbox "toggle cursor grid" "showcursorgrid"
-                guieditcheckbox "toggle selection grid" "showselgrid"
-                guieditcheckbox "snap ents to grid" "entselsnap"
-                guistrut 0.5
                 guieditcheckbox "toggle allfaces texture mode" "allfaces"
+                guistrut 0.5
+                guieditcheckbox "enable selection and editing of entities" entediting
+                guieditcheckbox "snap ents to the grid as they are moved" entselsnap
+                guistrut 0.5
+                guitext "^faplace new entities:"
+                i = (& $entdrop 2)
+                guibitfield "on selected area" entdrop 2 
+                // next checkbox is just the opposite of this bitfield
+                guicheckbox "on camera position"  i 0 2 [entdrop (^ $entdrop 2)] 
+                guibitfield "drop to ground" entdrop 1
                 guistrut 0.5
                 guilist [ 
                     guitext "threads to compute lightmaps in parallel "
@@ -242,6 +309,7 @@
                     guispring 1
                     guifield floatspeed 6 [ floatspeed $floatspeed ]
                 ]
+                guistrut 0.5
                 guitext (format "current editing grid size: %1" (<< 1 $gridpower))
                 guislider gridpower 0 (min (- $mapsize 1) 12) 
                 guistrut 0.5
@@ -249,8 +317,40 @@
                 guislider undomegs 1 10
             ]
         ]    
+
+        guitab view
+        guieditcheckbox "toggle outline" "outline"
+        guibutton "change outline colour" [pickcolour outlinecolour] [] $editingtex
+        guistrut 0.5
+        guieditcheckbox "toggle fullbright" "fullbright"
+        guieditcheckbox "toggle wireframe" "wireframe"
+        guieditcheckbox "toggle blank geometry" "blankgeom"
+        guistrut 0.5
+        guieditcheckbox "toggle paste grid" showpastegrid
+        guieditcheckbox "toggle cursor grid" showcursorgrid
+        guieditcheckbox "toggle selection grid" showselgrid
+        guistrut 0.5
+        guieditcheckbox "show edit radar:" showeditradar
+        guiradio "sectional compass" editradarstyle 0
+        guiradio "compass-distance " editradarstyle 1
+        guiradio "full hud" editradarstyle 2
+        guilist [
+            guiradio "minimap" editradarstyle 3
+            guispring 1
+            guibutton "refresh" [minimapsize @minimapsize]
+            guispring 1
+            guibutton "customize" [showgui world 6]
+        ]
+        guistrut 1
+        guilist [
+            guitext "radar distance (zoom out)"
+            guispring 1
+            guiradio "full map size" editradardist 0
+        ]
+        guislider editradardist 16 (<< 1 $mapsize)
+
         if (isonline) [
-            guitab editlock
+            guitab lock
             guitext "admins can restrict editing by auth rank"
             guilist [
                 guitext "when the server is locked:"
@@ -275,7 +375,7 @@
                     guispring 1
                     looplist v [spawneditlock editlock] [   // spawnlock connectlock varslock ... keep it simple
                         guibody [
-                        	guiimage [textures/privs/@priv] [] 1 1 "" [] (? (>= $i $$v) 0x00ff00 0xff0000)
+                        	guiimage [textures/privs/@priv] [] 0.8 1 "" [] (? (>= $i $$v) 0x00ff00 0xff0000)
                         ] [@v @i] [saycommand /@v @i] [guitooltip [/@@v @@i]]
                         guispring 1
                     ]
@@ -1239,6 +1339,7 @@
                         guitext "you can also proceed here if you simply"
                         guistrut 1
                         guieditbutton "select all entities on this map" [entfind]
+                        guieditbutton "or in the selected volume" [entfindinsel]
                     ]
                 ]
             ]
@@ -1811,4 +1912,3 @@
             ]
         ]
     ]
-

--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -2,12 +2,14 @@
     // button for editing commands with built-in
     // key display, tooltip and r-click for console
     guieditbutton = [ 
+        local cmd // in case there is semicolon to escape
+        cmd = (stringreplace $arg2 ";" "^";^"")
         guibody [     
             guibutton $arg1
             guistrut 0.5
             guispring 1
             guibutton (dobindsearch [@arg2] edit) 
-        ] [@arg2] [saycommand /@arg2] [guitooltip [/@@arg2]]
+        ] [@arg2] [saycommand /@cmd] [guitooltip [/@@arg2]]
     ]
 
     // same for looking up an editvarbind on a checkbox


### PR DESCRIPTION
enhance guieditbutton, such that alt-actions with semicolons work properly, too
tweak the compass again, put map info menu first, hotkey A
remove sendmap button
fix layout on num/maxplayers, clarify mapbalance
add map loading tab to map info menu: quickly start a new edit session
design the load menu such that home/temp/maps are supported
allow to browse maps by category: current, custom, main, race, small, medium, large and temp
split editing view options into  a separate tab
add checkbox/bitfields to disable entity editing and to control how new ents are placed / dropped
add more view options for editradar, including minimap distance (zoom slider)
detail: add entfindinsel button to entity editing if none are selected