### PR TITLE
improve colour/shader options in editing menus

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -1,4 +1,5 @@
 
+
     // button for editing commands with built-in
     // key display, tooltip and r-click for console
     guieditbutton = [ 
@@ -437,6 +438,7 @@
                     loop i (min 15 $imax) [
                         p = (at $prefabs (+ $i $slider))
                         guieditbutton $p [pasteprefab @p] 
+                        // guiprefabpreview $p "" [pasteprefab @p] 2 1 
                     ]
                 ]
                 if (slidermax) [guislider slider 0 $slidermax [] 1 1]
@@ -1054,6 +1056,11 @@
         guilist [
             guispring 1
             guilist [
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
                 guitext "rotation or flip:"
                 guiright [guieditbutton2 "90 degree"  [vrotate 1]]
                 guiright [guieditbutton2 "180 degree"  [vrotate 2]]
@@ -1061,9 +1068,18 @@
                 guiright [guieditbutton2 "left to right" [vrotate 4]]
                 guiright [guieditbutton2 "top to bottom" [vrotate 5]]
                 guiright [guieditbutton2 "reset"  [vrotate 0]]
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
             ]
             guispring 1
             guilist [
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
                 guitext "texture offset:"
                 guieditbutton "move up" [vdelta voffset 0 (* -1 @varpix)] [] $arrowtex
                 guieditbutton "move down" [vdelta voffset 0  @varpix] [] $arrowdowntex
@@ -1075,9 +1091,18 @@
                     guitext " ^fapixels"
                 ]
                 guieditbutton "reset offset" [voffset 0 0] [] 
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
             ]
             guispring 1
             guilist [
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
                 guitext "scale:"
                 guieditbutton "800.0%" [vscale 8]
                 guieditbutton "400.0%" [vscale 4]
@@ -1086,34 +1111,71 @@
                 guieditbutton " 50.0%" [vscale 0.5]
                 guieditbutton " 25.0%" [vscale 0.25]
                 guieditbutton " 12.5%" [vscale 0.25]
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
             ]
             guispring 1
             guilist [
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
                 guitext "scrolling:"
                 guieditbutton "+horizontal" [vdelta vscroll 0.1 0]
                 guieditbutton "-horizontal" [vdelta vscroll -0.1 0]
                 guieditbutton "+vertical" [vdelta vscroll 0 0.1]
                 guieditbutton "-vertical" [vdelta vscroll 0 -0.1]
                 guieditbutton "stop moving" [vscroll 0 0]
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
             ]
             guispring 1
         ]
         guistrut 1
-        guicenter [ guitext "customize the opacity when inside alpha material:" ]
         guicenter [ 
-            guifield vara 3 
-            guitext " front side"
-            guistrut 3
-            guifield vara2 3 
-            guitext " back side"
-            guistrut 3
-            guieditbutton "apply" [valpha $vara $vara2]
+            guilist [ 
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
+                        guitext "customize the opacity when inside alpha material:" 
+                        guilist [
+                            guifield vara 3 
+                            guitext " front side"
+                            guistrut 3
+                            guifield vara2 3 
+                            guitext " back side"
+                            guistrut 3
+                            guieditbutton "apply" [valpha $vara $vara2]
+                        ]
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
+            ]
         ]
 
-        guitab colour
+        guitab colours
         if (= $guipasses 0) [hex = 0xffffff]
         guistrut 1
-        guicenter [ guitext "pick a colour to scale the red, green and blue component of the texture" ]
+        guicenter [ guitext "pick a colour to scale the red, green and blue component of the texture or" ]
+        guicenter [
+            guitext "of its shaders. Tip: Use"
+            guistrut 1
+            guibutton "white to ^fgreset" [hex = 0xffffff]
+            guistrut 1
+            guitext "and"
+            guistrut 1
+            guibutton "black to ^fydisable" [hex = 0x000000]
+            guistrut 1
+            guitext "a property"
+        ]
         guistrut 1
         guilist [
             guistrut 2
@@ -1124,99 +1186,73 @@
             ]
             guispring 1
             guilist [
-                guieditbutton "replace the r g b factors" [vcolour @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "alter the r g b factors" [vdelta vcolour @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "reset to original colour" [vcolour 1 1 1] 
+                guibackground 0 0 0xffffff 1 1
+                guistrut 0.2
+                guilist [
+                    guistrut 0.8
+                    guilist [
+                        guieditbutton "texture" [vcolour @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                        guieditbutton "curr. tex" [vdelta vcolour @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                        guieditbutton "specular" [vdelta vshaderparam specscale @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                    ]
+                    guistrut 2
+                    guilist [
+                        guieditbutton "glow effect" [vdelta vshaderparam glowcolor @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                        guieditbutton "pulse-glow" [vdelta vshaderparam pulseglowcolor @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                        guieditbutton "env-map" [vdelta vshaderparam envscale @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
+                    ]
+                    guistrut 0.8
+                ]
+                guistrut 0.2
             ]
         ]
         guistrut 1
         guipalette 0.6
 
-        guitab glow
-        if (= $guipasses 0) [hex = 0xffffff]
+        guitab palette
+        if (= 0 $guipasses) [tb = 0; wb = 0]
         guistrut 1
-        guicenter [ guitext "pick a colour for the glow effect - requires a glowmap texture" ]
+        guitext "set palette for texture colouring" 
         guistrut 1
-        guilist [
-            guistrut 2
-            guihexpreview $hex glow
-            guistrut 2
-            guilist [
-                guirgbsliders hex
-            ]
+    	guilist [
+    	    guilist [
+                guitext "disabled"
+    	        guiimage $warningtex [vpalette 0 0] 1.5 1 
+    	    ]
             guispring 1
-            guilist [
-                guieditbutton "set and keep other shaders" [vdelta vshaderparam glowcolor @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "set and ^fyclear^fw other shaders" [vshaderparam glowcolor @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "disable glow" [vdelta vshaderparam glowcolour 0 0 0] 
-            ]
-        ]
+    	    guilist [
+                guitext "flashing colours"
+    	        guilist [
+    	            guiimage $burningtex [vpalette 0 1] 1.5 1 
+    	            guiimage $modekaboomtex [vpalette 0 2] 1.5 1 
+    	            guiimage $bombtex [vpalette 0 3] 1.5 1 
+    	            guiimage $shockingtex [vpalette 0 4] 1.5 1 
+    	        ]
+                guistrut 1
+    	    ]
+            guispring 1
+    	    guilist [
+                guitext "team colour variables"
+    	        guilist [
+    	            guiimage $modeffatex [vpalette 1 0] 1.5 1 
+                    i = 1
+                    looplist p [alpha omega kappa sigma ] [
+    	                guiimage $[team@[p]tex] [vpalette 1 (+ @i $tb)] 1.5 1 "" [] $[team@[p]colour]
+                        i = (+ 1 $i)
+    	            ]
+    	        ]
+                guicheckbox "only applied in team games" tb 0 5
+    	    ]
+    	]
         guistrut 1
-        guipalette 0.6
-
-        guitab specular
-        if (= $guipasses 0) [hex = 0xffffff]
-        guistrut 1
-        guicenter [ guitext "pick a colour for specular lighting - requires a normalmap texture" ]
-        guistrut 1
-        guilist [
-            guistrut 2
-            guihexpreview $hex shine
-            guistrut 2
-            guilist [
-                guirgbsliders hex
-            ]
-            guispring 1
-            guilist [
-                guieditbutton "set and keep other shaders" [vdelta vshaderparam specscale @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "set and ^fyclear^fw other shaders" [vshaderparam specscale @(divf $colr 255) @(divf $colg 255) @(divf $colb 255) ] 
-                guieditbutton "disable specular" [vdelta vshaderparam specscale 0 0 0]
-            ]
-        ]
-        guistrut 1
-        guipalette 0.6
-
-        guitab parallax
-        if (= $guipasses 0) [val1 = 0; val2 = 0]
-        guistrut 1
-        guicenter [ guitext "parallax deforms the texture for a pseudo-3d-effect based on the normal map" ]
-        guistrut 1
-        guicenter [ guitext "The distortions depend on the distance to the observer"]
-        guicenter [ guitext "WARNING: Use very small values or strange effects can and will result"]
-        guistrut 1
-        guilist [
-            guifield val1 12
-            guistrut 1
-            guitext "scaling factor " 
-            guispring 1
-            guieditbutton "set and keep other shaders" [vdelta vshaderparam parallaxscale @val1 @val2] [] 
-        ]
-        guilist [
-            guifield val2 12
-            guistrut 1
-            guitext "offset" 
-            guispring 1
-            guieditbutton "set and ^fyclear^fw other shaders" [vshaderparam parallaxscale @val1 @val2] [] 
-        ]
-        guilist [
-            guispring 1
-            guieditbutton "disable parallax" [vdelta vshaderparam parallaxscale 0 0 ] [] 
-        ]
-        guistrut 2
-        guilist [
-            guitext "some examples:"
-            guispring 1
-            guibutton "moderate"   [saycommand /vdelta vshaderparam parallaxscale 0.02 0.0]
-            guispring 1
-            guibutton "strong"     [saycommand /vdelta vshaderparam parallaxscale 0.05 0.0]
-            guispring 1
-            guibutton "inverted"   [saycommand /vdelta vshaderparam parallaxscale -0.02 0.0]
-            guispring 1
-            guibutton "soft blob"  [saycommand /vdelta vshaderparam parallaxscale 0.0 -0.02]
-            guispring 1
-            guibutton "fish eye"   [saycommand /vdelta vshaderparam parallaxscale 0.0 2.0]
-            guispring 1
-        ]
+        guitext "weapon colour variables"
+    	guilist [
+    	    loop i $weapidxnum [
+                w = (at $weapname $i)
+    	        guiimage $[@[w]tex] [vpalette 2 (+ @i $wb)] 1.5 1 "" [] $[@[w]colour]
+    	    ]
+    	]
+        guicheckbox "only applied if the weapon is allowed to spawn" wb 0 $weapidxnum
 
         guitab blend
         if (= 0 $guipasses) [slotnum = 1]
@@ -1264,6 +1300,132 @@
                 guieditbutton "^foclear^fw the entire blendmap" clearblendmap
             ]
         ]
+
+                guitab shaders
+        if (= $guipasses 0) [
+            par1 = 0.05
+            par2 = 0.0
+            pt = 1.0
+        ]
+        guistrut 0.5
+        guicenter [ guitext "edit more shader settings"]
+        guistrut 0.5
+        guicenter [ guilist [ guilist [
+            guibackground 0 0 0xffffff 1 1
+            guistrut 0.8
+            guilist [
+                guistrut 0.2
+                guitext "parallax deforms the texture for a pseudo-3d-effect based on the normal map:" 
+                guistrut 0.5
+                guilist [
+                    guifield par1 12
+                    guistrut 1
+                    guitext "scaling factor " 
+                    guispring 1
+                    guifield par2 12
+                    guistrut 1
+                    guitext "offset" 
+                    guispring 1
+                    guieditbutton "^fgapply" [vdelta vshaderparam parallaxscale @par1 @par2]  
+                    guispring 1
+                ]
+                guilist [
+                    guitext "some examples:"
+                    guispring 1
+                    guibutton "moderate"   [par1 = 0.02; par2 = 0.0]
+                    guispring 1
+                    guibutton "strong"     [par1 = 0.05; par2 = 0.0]
+                    guispring 1
+                    guibutton "inverted"   [par1 = -0.02; par2 = 0.0]
+                    guispring 1
+                    guibutton "soft blob"  [par1 = 0.00; par2 = -0.02]
+                    guispring 1
+                    guibutton "fish eye"   [par1 = 0.00; par2 = 2.0]
+                    guispring 1
+                ]
+                guistrut 0.2
+            ]
+            guistrut 0.8
+        ] ] ]
+        guistrut 0.5
+        guicenter [ guilist [ guilist [
+            guibackground 0 0 0xffffff 1 1
+            guistrut 0.8
+            guilist [
+                guistrut 0.6
+                guilist [
+                    guifield pt 4
+                    guistrut 1
+                    guitext "Hz" 
+                    guistrut 3
+                    guieditbutton "set pulse" [vdelta vshaderparam pulsespeed @pt]
+                    guistrut 3
+                    guieditbutton "set pulseglow" [vdelta vshaderparam pulseglowspeed @pt]
+                ]
+                guistrut 0.2
+            ]
+            guistrut 0.8
+        ] ] ]
+        guistrut 0.5
+        if (= $guipasses 0) [
+            texs = (loopconcat i 5 [result (gettexname $getseltex $i)])
+            tn = (listlen $texs)
+            loop i $tn [
+                t = (at $texs $i)
+                do [s@i = (substring $t (+ (stringstr $t "_") 1) 1)]
+            ]
+            s0 = "c"
+        ]
+        guicenter [ guilist [ guilist [
+            guibackground 0 0 0xffffff 1 1
+            guistrut 0.8
+            guilist [
+                guistrut 0.2
+                texs = (loopconcat i 5 [result (gettexname $getseltex $i)])
+                if (stringlen $texs) [
+                    guilist [
+                        guibutton "experimental feature:^nadd texture slot^nwith selected shaders^nand current textures" [
+                            t = ""
+                            looplist i [bump env specmap parallax pulse glow] [
+                                if $[s@i] [t = (concatword $t $i)]
+                            ]
+                            setshader (concatword $t "world")
+                            echo setshader (concatword $t "world")
+                            loop i $tn [
+                                texture $[s@i] (at $texs $i) 0 0 0 0.5 
+                                echo texture $[s@i] (at $texs $i) 0 0 0 0.5 
+                            ]
+                            //here we need a workaround to get the newly added texture slot
+                            loopwhile i 1200 [!=s "textures/default.png" (gettexname (+ 2 $i))] [j = (+ 2 $i)]
+                            //apply the new texture to the selection:
+                            echo new slot number $j
+                            settex $j
+                        ]
+                        guistrut 2
+                        guilist [
+                            looplist i [bump env specmap parallax pulse glow] [
+                                guicheckbox $i [s@i] 1 0 
+                            ]
+                        ]
+                        guistrut 2
+                        guilist [
+                            loop i $tn [
+                                guilist [
+                                    guifield [s@i] 1
+                                    guistrut 1
+                                    t = (at $texs $i)
+                                    guitext $t [../@t]
+                                ]
+                            ]
+                        ]
+                    ]
+                ] [
+                    guitext "no texture selected"
+                ]
+                guistrut 0.2
+            ]
+            guistrut 0.8
+        ] ] ]
     ] ]
 
     slider = 0
@@ -1448,6 +1610,14 @@
                             ]
                             if (=s $a colour) [
                                 guibutton pick [pickattr = @iattr; showgui entcolour] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a green) [
+                                guibutton pick [pickattr = @iattr; showgui entcolours] -1 $editingtex
+                                guistrut 1
+                            ]
+                            if (=s $a palette) [
+                                guibutton pick [pickattr = @iattr; showgui entpalette] -1 $editingtex
                                 guistrut 1
                             ]
                             if (=s $a dir) [
@@ -1690,6 +1860,74 @@
         ]
         guipalette 0.6
     ] ]
+
+    newgui entcolours [ guistayopen [
+        if (= $guipasses 0) [
+            hex = (+ (<< (entattr (- $pickattr 1)) 16) ( << (entattr $pickattr) 8) (entattr (+ $pickattr 1)))
+        ]
+        guistatus "press ^fcEsc^fw when done to return to the previous menu"
+        guitext (format "pick a colour for attributes %1, %2 and %3 of the selected %4" (- $pickattr 1) $pickattr (+ $pickattr 1) (enttype))
+        guistrut 1
+        guilist [
+            guihexpreview $hex hex-value
+            guistrut 1
+            guilist [guirgbsliders hex]
+            guistrut 2
+            guibutton "apply this colour" [
+                entattr (- $pickattr 1) @colr
+                entattr $pickattr  @colg
+                entattr (+ $pickattr 1) @colb
+            ] -1 $editingtex
+        ]
+        guipalette 0.6
+    ] ]
+
+
+    newgui entpalette [ 
+        if (= 0 $guipasses) [tb = 0; wb = 0; p = (+ $pickattr 1)]
+        guistrut 1
+        guitext (format "pick a palette for attributes %1 and %2 of the selected %3" $pickattr (+ $pickattr 1) (enttype))
+        guistrut 1
+    	guilist [
+    	    guilist [
+                guitext "disabled"
+    	        guiimage $warningtex [entattr $pickattr 0; entattr $p 0] 1.5 1 
+    	    ]
+            guispring 1
+    	    guilist [
+                guitext "flashing colours"
+    	        guilist [
+    	            guiimage $burningtex [entattr $pickattr 0; entattr $p  1] 1.5 1 
+    	            guiimage $modekaboomtex [entattr $pickattr 0; entattr $p 2] 1.5 1 
+    	            guiimage $bombtex [entattr $pickattr 0; entattr $p 3] 1.5 1 
+    	            guiimage $shockingtex [entattr $pickattr 0; entattr $p 4] 1.5 1 
+    	        ]
+                guistrut 1
+    	    ]
+            guispring 1
+    	    guilist [
+                guitext "team colour variables"
+    	        guilist [
+    	            guiimage $modeffatex [entattr $pickattr 1; entattr $p 0] 1.5 1 
+                    i = 1
+                    looplist p [alpha omega kappa sigma ] [
+    	                guiimage $[team@[p]tex] [entattr $pickattr 1; entattr $p (+ @i $tb)] 1.5 1 "" [] $[team@[p]colour]
+                        i = (+ 1 $i)
+    	            ]
+    	        ]
+                guicheckbox "only applied in team games" tb 0 5
+    	    ]
+    	]
+        guistrut 1
+        guitext "weapon colour variables"
+    	guilist [
+    	    loop i $weapidxnum [
+                w = (at $weapname $i)
+    	        guiimage $[@[w]tex] [entattr $pickattr 2 ; entattr $p (+ @i $wb)] 1.5 1 "" [] $[@[w]colour]
+    	    ]
+    	]
+        guicheckbox "only applied if the weapon is allowed to spawn" wb 0 $weapidxnum
+    ] 
 
     newgui sounds [ guistayopen [
         if (= 0 $guipasses) [


### PR DESCRIPTION
improve textures menu: 
 * merge tabs for colour, glow and specular, add options to set envscale and pulseglowcolor 
 * new shader tab for parallax, pulse speed and changing shaders (experimental)
 * new tab for vpalette with lots of buttons

improve entity attribute picking
 * same palette menu works for palette/palindex attrs, too
 * allow to pick red green blue attrs