### PR TITLE
add prefabpreview to editing menus

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -1,5 +1,4 @@
 
-
     // button for editing commands with built-in
     // key display, tooltip and r-click for console
     guieditbutton = [ 
@@ -434,14 +433,14 @@
             slidermax = (max (- $imax 15) 0)
             guicenter [
                 guilist [
-                    guistrut 40 1
+                    guistrut 15 1
                     loop i (min 15 $imax) [
                         p = (at $prefabs (+ $i $slider))
-                        guieditbutton $p [pasteprefab @p] 
-                        // guiprefabpreview $p "" [pasteprefab @p] 2 1 
+                        guibutton $p [pasteprefab @p] 
                     ]
                 ]
                 if (slidermax) [guislider slider 0 $slidermax [] 1 1]
+                guinohitfx [guiprefabpreview $guirollovername -1 [] 7.5 1 []]
             ]
         ] [
             guitext "no obr files found in home/prefab"
@@ -1301,7 +1300,7 @@
             ]
         ]
 
-                guitab shaders
+        guitab shaders
         if (= $guipasses 0) [
             par1 = 0.05
             par2 = 0.0
@@ -1375,6 +1374,9 @@
                 do [s@i = (substring $t (+ (stringstr $t "_") 1) 1)]
             ]
             s0 = "c"
+            looplist i [bump env specmap parallax pulse glow] [
+                do [s@i = 1]
+            ]
         ]
         guicenter [ guilist [ guilist [
             guibackground 0 0 0xffffff 1 1
@@ -1993,40 +1995,23 @@
         if (= 0 $guipasses) [
             slider = 0
             imax = (mapmodelindex)
+            slidermax = (max (- $imax 15) 0)
         ] 
         if (imax) [
             guitext "^fapick a mapmodel entity to create"
-            guicheckbox "show previews" mapmodelprevs
             guistrut 1
-            if $mapmodelprevs [
-                slidermax = (max (- $imax 4) 0)
-                guicenter [
-                    loop i (min 4 $imax) [
+            guicenter [
+                guilist [
+                    guistrut 20 1
+                    loop i (min 15 $imax) [
                         j = (+ $i $slider)
                         p = (mapmodelindex $j)
-                        guilist [
-                            guimodelpreview $p "mapmodel" [newent mapmodel @j] 6 1 
-                            guieditbutton (concat " " $p) [newent mapmodel @j] 
-                        ]
+                        guibutton $p [newent mapmodel @j] 
                     ]
-                    if (slidermax) [guislider slider 0 $slidermax [] 1 1]
                 ]
-            ] [
-                slidermax = (max (- $imax 15) 0)
-                guicenter [
-                    guilist [
-                        guistrut 20 1
-                        loop i (min 15 $imax) [
-                            j = (+ $i $slider)
-                            p = (mapmodelindex $j)
-                            if $mapmodelprevs [
-                                guimodelpreview $p "mapmodel" [newent mapmodel @j] 5 1 
-                            ]
-                            guieditbutton $p [newent mapmodel @j] 
-                        ]
-                    ]
-                    if (slidermax) [guislider slider 0 $slidermax [] 1 1]
-                ]
+                if (slidermax) [guislider slider 0 $slidermax [] 1 1]
+                guinohitfx [guimodelpreview $guirollovername "mapmodel" [] 7.5 1 ]
+                guitext $guirollovername
             ]
         ] [
             guitext "no mapmodels found for this map configuration"

--- a/config/menus/glue.cfg
+++ b/config/menus/glue.cfg
@@ -334,5 +334,5 @@ newgui pickcolour [ guistayopen [
     guipalette 0.65
 ] ]
 
-pickcolour = [ scurvar = $arg1 ; showgui pickcolour ]
+pickcolour = [ scurvar = $arg1 ; hex = $$arg1; showgui pickcolour ]
 


### PR DESCRIPTION
show a large prefabpreview in the geometry menu, tab 2
use the same new layout for the mapmodel menu:
    Preview to the right of the list, using the mouse rollover item
init checkboxes for experimental shader editing feature (just fixes a console error)
init sliders on colour picker to the current value of the variable