### PR TITLE
Fix inability to connect to `priv` servers using `servers` gui

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -280,7 +280,7 @@ servermenu = [
         if (=s $sinfonpid $sinforetry) [
             if (= $sinfowait 1) [
                 if (stringlen $sinfopass) [
-                    savewarnchk (format "connect %1 %2 %3" connect $sinfoname $sinfoport $sinfopass)
+                    savewarnchk (format "connect %1 %2 %3" $sinfoname $sinfoport $sinfopass)
                     sinfopass = ""
                     sinforetry = ""
                     sinfowait = 0


### PR DESCRIPTION
Appears if user has no auth and hence should enter password.