### PR TITLE
ircfilter: fix handling of 'end color formatting' character

### DIFF
--- a/src/engine/irc.cpp
+++ b/src/engine/irc.cpp
@@ -220,9 +220,12 @@ void irc2cube(char *dst, const char *src)
                 case '9': *dst++ = '\f'; *dst++ = 'g'; break; // green
                 default: *dst++ = '\f'; *dst++ = 'w'; c = *--src; break;
             }
-            continue;
         }
-        if(iscubeprint(c) || iscubespace(c)) *dst++ = c;
+        else if(c == '\x0F')
+        {
+            *dst++ = '\f'; *dst++ = 'w';
+        }
+        else if(iscubeprint(c) || iscubespace(c)) *dst++ = c;
     }
     *dst = '\0';
 }


### PR DESCRIPTION
This fixes ugly `E` characters that currently appear on place of `end color formatting` character.