### PR TITLE
add veto warning to maps menu

### DIFF
--- a/config/menus/maps.cfg
+++ b/config/menus/maps.cfg
@@ -445,14 +445,39 @@ mapsmenu = [
                 guiradio "public" servertype 2
             ]
             guispring 1
-            if (>= $lastmode 0) [
-                if (stringlen $mapcur) [
-                    guifont "default" [
-                        guistayopen [ guibutton (? (isonline) "^fgsubmit this vote" "^fgstart local game") [ mapsexec $mapcur $modeselected $mutsselected ] ]
+            guifont "default" [
+                if (>= $lastmode 0) [
+                    if (stringlen $mapcur) [
+                        guistayopen [
+                            if (getclientcount) [ 
+                                // other are players present
+                                if (&& (getclientpriv $getclientnum $vetolock) (=s (getmastermode 1) "veto")) [
+                                    guibutton "^fzwyforce new game (veto)" [ mapsexec $mapcur $modeselected $mutsselected ] 
+                                ] [
+                                    guibutton "^fgsubmit this vote" [ mapsexec $mapcur $modeselected $mutsselected ] 
+                                ]
+                            ] [
+                                //either playing offline or without other players 
+                                guibutton "^fgstart a new game" [ mapsexec $mapcur $modeselected $mutsselected ] 
+                            ]
+                            guistrut 14
+                        ]
+                    ] [
+                        guitext "^fy.. pick a map to continue .."
+                        guistrut 10
                     ]
-                    guistrut 14
-                ] [ guifont "default" [ guitext "^fy.. pick a map to continue .." ]; guistrut 10 ]
-            ] [ guifont "default" [ guitext "^fy.. pick a mode and map to continue .." ]; guistrut 6 ]
+                ] [
+                    guitext "^fy.. pick a mode and map to continue .."
+                    guistrut 6
+                ]
+            ]
+        ]
+        if (&& (getclientpriv $getclientnum $masterlock) (getclientcount)) [
+            guistrut 0.2
+            guistayopen [ guiright [
+                guibutton (concat "master mode:" (getmastermode 1)) [mastermode (! (getmastermode))]
+                guistrut 13.5 
+            ] ]
         ]
         guivisible [
             cases (at $guirolloveraction 0) "modeselected" [


### PR DESCRIPTION
replace the (isonline) check with a check for other players using (getclientcount)
this fixes the menu when servertype > 0 or when playing on a server without other players
show a warning when the privs and mastermode result in a veto, so games are not forced by mistake
show a mastermode button below, but only if other players are present and you have the privs