### PR TITLE
Add skippickup to disable pickup for skipped item weapons.

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -113,7 +113,7 @@ newgui options_graphics [
                     guiradio "^fosoft" glarepreset 3 [blurglare 7; glarescale 1]
                     guistrut 1
                     guiradio "^fointense" glarepreset 4 [blurglare 7; glarescale 2]
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAsubtle" radiodisable
                     guistrut 1
                     guitext "^fAglowy" radiodisable
@@ -128,7 +128,7 @@ newgui options_graphics [
                     guiradio "^fosubtle" motionblurscale 0.5
                     guistrut 1
                     guiradio "^fomoderate" motionblurscale 1
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAsubtle" radiodisable
                     guistrut 1
                     guitext "^fAmoderate" radiodisable
@@ -141,7 +141,7 @@ newgui options_graphics [
                     guiradio "^fymoderate fade" grassdist 256
                     guistrut 1
                     guiradio "^foslow fade" grassdist 512
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAquick fade" radiodisable
                     guistrut 1
                     guitext "^fAmoderate fade" radiodisable
@@ -154,7 +154,7 @@ newgui options_graphics [
                     guiradio "^fgmedium quality" maxdynlights 3
                     guistrut 1
                     guiradio "^fyhigh quality" maxdynlights 5
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAmedium quality" radiodisable
                     guistrut 1
                     guitext "^fAhigh quality" radiodisable
@@ -167,7 +167,7 @@ newgui options_graphics [
                     guiradio "^fymedium quality" depthfxsize 10 [blurdepthfx 0]
                     guistrut 1
                     guiradio "^fohigh quality" depthfxsize 12 [blurdepthfx 0]
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAlow quality" radiodisable
                     guistrut 1
                     guitext "^fAmedium quality" radiodisable
@@ -181,7 +181,7 @@ newgui options_graphics [
                     guiradio "^fgmedium quality" maxdecaltris 512
                     guistrut 1
                     guiradio "^fyhigh quality" maxdecaltris 1024
-                ] [ guinohitfx [ 
+                ] [ guinohitfx [
                     guitext "^fAmedium quality" radiodisable
                     guistrut 1
                     guitext "^fAhigh quality" radiodisable
@@ -334,6 +334,9 @@ newgui options_gameplay [
     guicheckbox "never use pistol" skippistol 10 0
     guicheckbox "never use grenades" skipgrenade 10 0
     guicheckbox "never use mines" skipmine 10 0
+    guicheckbox "never use rockets" skiprocket 10 0
+    guistrut 0.5
+    guicheckbox "disallow pickups of selected weapons" skippickup
     guistrut 1
     guilist [
         guitext "weapon zoom level:"
@@ -1133,74 +1136,74 @@ bindtypes = [ default spectator editing waiting ]
 bindcalls = [ "" spec edit wait ]
 
 bindactions = [
-    forward backward left right 
-    "primary" "secondary" "reload" "jump" "crouch" "special" "universaldelta 1" "universaldelta -1" 
+    forward backward left right
+    "primary" "secondary" "reload" "jump" "crouch" "special" "universaldelta 1" "universaldelta -1"
     "weapon 1" "weapon 2" "weapon 3" "weapon 4" "weapon 5" "weapon 6" "weapon 7" "weapon 8" "weapon 9" "weapon 10"
     walk use drop affinity
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)"
     "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
     "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
-    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
-    "spectator 1" addbot delbot   
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot
+    "spectator 1" addbot delbot
 ]
 bindtitles = [
-    forward backward left right 
-    "primary" "secondary" "reload" "jump" "crouch" "parkour/kick" "next weapon" "previous weapon" 
+    forward backward left right
+    "primary" "secondary" "reload" "jump" "crouch" "parkour/kick" "next weapon" "previous weapon"
     "weap slot 1" "weap slot 2" "weap slot 3" "weap slot 4" "weap slot 5" "weap slot 6" "weap slot 7" "weap slot 8" "weap slot 9" "weap slot 10"
     walk "use / pick up" "drop weapon" "throw flag/bomb"
-    "cmd input" "all chat" "team chat" 
+    "cmd input" "all chat" "team chat"
     "voice compass" "team compass" "bot compass"
     "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
     "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
-    "enter spectator" "add bot" "delete bot" 
+    "enter spectator" "add bot" "delete bot"
 ]
 
 specbindactions = [
-    forward backward left right "universaldelta 1" "universaldelta -1" 
+    forward backward left right "universaldelta 1" "universaldelta -1"
     specmodeswitch [if (! $isonline) [sv_gamespeed 10000; onrelease [sv_gamespeed 100]]] "spectator 0"
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)"
     "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
     "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
-    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
-    "spectator 1" addbot delbot   
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot
+    "spectator 1" addbot delbot
 ]
 specbindtitles = [
-    forward backward left right "watch next player" "watch previous player" 
+    forward backward left right "watch next player" "watch previous player"
     "toggle TV mode" "fast forward (offline)" "exit spectator"
-    "cmd input" "all chat" "team chat" 
+    "cmd input" "all chat" "team chat"
     "voice compass" "team compass" "bot compass"
     "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
     "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
-    "enter spectator" "add bot" "delete bot" 
+    "enter spectator" "add bot" "delete bot"
 ]
 
 waitbindactions = [
     forward backward left right "universaldelta 1" "universaldelta -1" "spectator 1"
     waitmodeswitch
-    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)" 
+    "saycommand /" "saytextcommand (getsaycolour)" "sayteamcommand (getsaycolour)"
     "showgui help" edittoggle "showgui maps 1" "showgui maps 2" "showservers" "showgui profile 2"
-    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot 
-    "spectator 1" addbot delbot   
+    "showgui team" "setpriv 1"  thirdpersonswitch "grabinput (! $grabinput)" toggleconsole screenshot
+    "spectator 1" addbot delbot
     "showcompass voice" "showcompass team" [if (&& (! (& (mutators) $mutsbitffa)) (!= (gamemode) 6)) [showcompass bot]]
 ]
 waitbindtitles = [
-    forward backward left right "scroll up" "scroll down" "enter spectator" 
+    forward backward left right "scroll up" "scroll down" "enter spectator"
     "switch wait TV mode"
-    "cmd input" "all chat" "team chat" 
-    "voice compass" "team compass" "bot compass" 
+    "cmd input" "all chat" "team chat"
+    "voice compass" "team compass" "bot compass"
     "help menu" "toggle editing" "maps menu" "show votes menu" "server menu" "loadout menu"
     "team menu" "claim privileges" "toggle thirdperson" "free mouse pointer" "toggle console" "screenshot"
-    "enter spectator" "add bot" "delete bot" 
+    "enter spectator" "add bot" "delete bot"
 ]
 
 editbindactions = [
-    "showtexgui" edittoggle "showgui edit" "remip" "fullbright 0; patchlight" 
+    "showtexgui" edittoggle "showgui edit" "remip" "fullbright 0; patchlight"
     "fullbright 0; calclight -1" "fullbright 0; calclight 1" savemap "changeoutline 1"
     [showcompass editing] [showgui materials] [if $blendpaintmode paintblendmap editdrag]
-    [if $blendpaintmode rotateblendbrush editextend] selcorners  "universaldelta 1" "universaldelta -1" 
-    cancelsel entcancel editdel editcopy editpaste editcut editflip 
+    [if $blendpaintmode rotateblendbrush editextend] selcorners  "universaldelta 1" "universaldelta -1"
+    cancelsel entcancel editdel editcopy editpaste editcut editflip
     gettex entlink selentedit "entselect insel"
-    "undo; passthroughsel 0" redo getmap sendmap 
+    "undo; passthroughsel 0" redo getmap sendmap
     "domodifier 1" "domodifier 2" "domodifier 3" "domodifier 4" "domodifier 6" "domodifier 9"
     "domodifier 10; onrelease entautoview" togglegrid
     [fullbright (= $fullbright 0); if (= $fullbright 0) [echo fullbright OFF] [ echo fullbright ON]]
@@ -1210,18 +1213,18 @@ editbindactions = [
     [hmapedit 0;
     blendpaintmode (? (= $blendpaintmode (getvarmax blendpaintmode)) 0 (+ $blendpaintmode 1))
     echo (concatword "^fgblend mode:^fw " (at $paintmodes $blendpaintmode) " (^fc" $blendpaintmode "^fw)")]
-    "hmapedit (! $hmapedit); blendpaintmode 0" 
+    "hmapedit (! $hmapedit); blendpaintmode 0"
     "hmapedit 0; blendpaintmode 0"
 ]
 editbindtitles = [
     "texture menu"  "toggle editing" "editing menu" "remip" "patch lights"
-    "quick calclight" "full calclight" "save map" "change outline" 
+    "quick calclight" "full calclight" "save map" "change outline"
     "editing compass" "materials menu" "select faces" "extend selection" "select corners" "pull cubes" "push cubes"
     "deselect all" "deselect ents" "delete ents, geometry" "copy selection" "paste" "cut/paste on release" "flip geometry"
     "grab texture" "link entities" "edit selected ent" "pick ents in selection"
-    undo redo "get map from server" "send map to server" 
-    "change grid size" "push/pull cube face" "push/pull cube corner" "rotate" "cycle textures" "cycle heightmap brush" "view selected ents" 
-    "cycle paste grid"  "toggle full bright" "toggle materials" "toggle outline" "toggle all faces" 
+    undo redo "get map from server" "send map to server"
+    "change grid size" "push/pull cube face" "push/pull cube corner" "rotate" "cycle textures" "cycle heightmap brush" "view selected ents"
+    "cycle paste grid"  "toggle full bright" "toggle materials" "toggle outline" "toggle all faces"
     "toggle blendmap mode" "toggle heightmap" "quit blend/heightmap"
 ]
 
@@ -1318,7 +1321,7 @@ newgui options_controls [
         guistrut 1
         // keys as listed in config/keyref.cfg with some different ordering
         guilistsplit curkey 5 [
-            A B C D E F G H I J K L M N O P Q R S T U V W X Y Z SPACE BACKSPACE 
+            A B C D E F G H I J K L M N O P Q R S T U V W X Y Z SPACE BACKSPACE
             0 1 2 3 4 5 6 7 8 9
             F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 F12 F13 F14 F15
             TAB RETURN ESCAPE
@@ -1333,7 +1336,7 @@ newgui options_controls [
             RSHIFT LSHIFT RCTRL LCTRL RALT LALT RMETA LMETA LSUPER RSUPER
             MODE COMPOSE HELP PRINT SYSREQ BREAK MENU POWER EURO UNDO
             ] [
-            guilist [ 
+            guilist [
                 guistayopen [
                     curbindacts = (getbind $curkey)
                     guibody [guiimage "textures/player"    [saycommand /bind @curkey "["@curbindacts"]"] 0.5 0 [] "" (? (stringlen $curbindacts) 0x66ff66 0x666666)] [] [] (? (stringlen $curbindacts) [guitooltip (getbind $curkey)])

--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -17,6 +17,8 @@ setdesc "skipspawnweapon" "skip spawnweapon;^n0 = never, 1 = if numweaps > 1 (+1
 setdesc "skipmelee" "skip melee;^n0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always" "<value>"
 setdesc "skippistol" "skip pistol;^n0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always" "<value>"
 setdesc "skipgrenade" "skip grenade;^n0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always" "<value>"
+setdesc "skiprocket" "skip rocket;^n0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always" "<value>"
+setdesc "skippickup" "disallow pickups for skipped weapons" "<value>"
 setdesc "weapselectslot" "determines how weapons are selected using the number keys;^n0 = by global weapon numbers, 1 = by temporary pickup slot numbers" "<bool>"
 setdesc "showaiinfo" "determines how much info is shown for bots;^n0 = hide bot info, 1 = show bot joins/parts, 2 = show more verbose info" "<value>"
 setdesc "demoautoclientsave" "determines if the client automatically saves demos after each match" "<value>"

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -621,6 +621,7 @@ namespace entities
                     if(game::allowmove(f))
                     {
                         int sweap = m_weapon(game::gamemode, game::mutators), attr = w_attr(game::gamemode, game::mutators, e.type, e.attrs[0], sweap);
+                        if(!weapons::canuse(attr)) return true;
                         if(!f->canuse(e.type, attr, e.attrs, sweap, lastmillis, (1<<W_S_SWITCH)))
                         {
                             if(e.type != WEAPON) return false;

--- a/src/game/entities.cpp
+++ b/src/game/entities.cpp
@@ -621,7 +621,7 @@ namespace entities
                     if(game::allowmove(f))
                     {
                         int sweap = m_weapon(game::gamemode, game::mutators), attr = w_attr(game::gamemode, game::mutators, e.type, e.attrs[0], sweap);
-                        if(!weapons::canuse(attr)) return true;
+                        if(f == game::player1 && !weapons::canuse(attr)) return true;
                         if(!f->canuse(e.type, attr, e.attrs, sweap, lastmillis, (1<<W_S_SWITCH)))
                         {
                             if(e.type != WEAPON) return false;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1593,6 +1593,7 @@ namespace weapons
     extern bool doshot(gameent *d, vec &targ, int weap, bool pressed = false, bool secondary = false, int force = 0);
     extern void shoot(gameent *d, vec &targ, int force = 0);
     extern void preload();
+    extern bool canuse(int weap);
 }
 
 namespace hud

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1551,7 +1551,7 @@ namespace hud
                                 if(enttype[e.type].usetype == EU_ITEM && e.type == WEAPON)
                                 {
                                     int sweap = m_weapon(game::gamemode, game::mutators), attr = w_attr(game::gamemode, game::mutators, e.type, e.attrs[0], sweap);
-                                    if(target->canuse(e.type, attr, e.attrs, sweap, lastmillis, (1<<W_S_SWITCH)|(1<<W_S_RELOAD)))
+                                    if(target->canuse(e.type, attr, e.attrs, sweap, lastmillis, (1<<W_S_SWITCH)|(1<<W_S_RELOAD)) && weapons::canuse(attr))
                                     {
                                         int drop = -1;
                                         if(m_classic(game::gamemode, game::mutators) && target->ammo[attr] < 0 && w_carry(attr, sweap) && target->carry(sweap) >= maxcarry)

--- a/src/game/weapons.cpp
+++ b/src/game/weapons.cpp
@@ -9,6 +9,9 @@ namespace weapons
     VAR(IDF_PERSIST, skippistol, 0, 0, 10); // skip pistol; 0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always
     VAR(IDF_PERSIST, skipgrenade, 0, 0, 10); // skip grenade; 0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always
     VAR(IDF_PERSIST, skipmine, 0, 0, 10); // skip mine; 0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always
+    VAR(IDF_PERSIST, skiprocket, 0, 0, 10); // skip mine; 0 = never, 1 = if numweaps > 1 (+2), 4 = if carry > 0 (+2), 7 = if carry > 0 and is offset (+2), 10 = always
+
+    VAR(IDF_PERSIST, skippickup, 0, 0, 1);
 
     int lastweapselect = 0;
     VAR(IDF_PERSIST, weapselectdelay, 0, 200, VAR_MAX);
@@ -123,8 +126,12 @@ namespace weapons
                     skipweap(skipspawnweapon, p);
                     skipweap(skipmelee, W_MELEE);
                     skipweap(skippistol, W_PISTOL);
-                    skipweap(skipgrenade, W_GRENADE);
-                    skipweap(skipmine, W_MINE);
+                    if(!m_kaboom(game::gamemode, game::mutators))
+                    {
+                        skipweap(skipgrenade, W_GRENADE);
+                        skipweap(skipmine, W_MINE);
+                        skipweap(skiprocket, W_ROCKET);
+                    }
                 }
 
                 if(weapselect(d, n, (1<<W_S_SWITCH)|(1<<W_S_RELOAD)))
@@ -138,6 +145,16 @@ namespace weapons
         game::errorsnd(d);
     }
     ICOMMAND(0, weapon, "ss", (char *a, char *b), weaponswitch(game::player1, *a ? parseint(a) : -1, *b ? parseint(b) : -1));
+
+    bool canuse(int weap)
+    {
+        if(!skippickup || m_kaboom(game::gamemode, game::mutators)) return true;
+        #define canuseweap(q,w) if(q && weap == w) return false;
+        canuseweap(skipgrenade, W_GRENADE);
+        canuseweap(skipmine, W_MINE);
+        canuseweap(skiprocket, W_ROCKET);
+        return true;
+    }
 
     void weapdrop(gameent *d, int w)
     {


### PR DESCRIPTION
Closes #285 
Also disables `skip<weap>` on explosives when in kaboom.