### PR TITLE
Give the genkey executable the ability to test if auth keys match.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -238,7 +238,7 @@ genkey: genkey$(BIN_SUFFIX)
 genkey$(BIN_SUFFIX): $(GENKEY_OBJS)
 	$(CXX) $(CXXFLAGS) -o genkey$(BIN_SUFFIX) $(GENKEY_OBJS)
 
-engine/genkey.o:
+engine/genkey.o: engine/genkey.cpp
 	$(CXX) $(CXXFLAGS) $(SERVER_INCLUDES) -c -o engine/genkey.o engine/genkey.cpp
 
 $(INSTDIR)/%$(BIN_SUFFIX): %$(APPMODIFIER)$(BIN_SUFFIX)

--- a/src/engine/genkey.cpp
+++ b/src/engine/genkey.cpp
@@ -8,11 +8,23 @@
 
 int main(int argc, char **argv)
 {
-    if(argc < 2) return EXIT_FAILURE;
-    vector<char> privkey, pubkey;
-    genprivkey(argv[1], privkey, pubkey);
-    printf("private key: %s\n", privkey.getbuf());
-    printf("public key: %s\n", pubkey.getbuf());
-    return EXIT_SUCCESS;
+    //Generate key pair: genkey <seed>
+    if(argc == 2)
+    {
+        vector<char> privkey, pubkey;
+        genprivkey(argv[1], privkey, pubkey);
+        printf("private key: %s\n", privkey.getbuf());
+        printf("public key: %s\n", pubkey.getbuf());
+        return EXIT_SUCCESS;
+    }
+    //Print yes/no to match pubkey with privkey: genkey <pubkey> <privkey>
+    else if(argc == 3)
+    {
+        vector<char> pubkey;
+        genpubkey(argv[2], pubkey);
+        printf("%s\n", !strcmp(argv[1], pubkey.getbuf()) ? "yes" : "no");
+        return EXIT_SUCCESS;
+    }
+    return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
Idea from http://redeclipse.net/forum/viewtopic.php?f=7&t=755
The genkey executable now has two modes:
* Generating: `genkey <seed>`
* Testing: `genkey <pubkey> <privkey>`

Testing will return 'yes' or 'no' in the output.