### PR TITLE
Store number of actual players (not idlers and unique in handle and IP)

### DIFF
--- a/sql/stats/create.sql
+++ b/sql/stats/create.sql
@@ -8,7 +8,8 @@ CREATE TABLE games (
     map TEXT,
     mode INTEGER,
     mutators INTEGER,
-    timeplayed INTEGER
+    timeplayed INTEGER,
+    uniqueplayers INTEGER
 );
 
 CREATE TABLE game_servers (

--- a/sql/stats/upgrade_2.sql
+++ b/sql/stats/upgrade_2.sql
@@ -1,0 +1,2 @@
+/* DB Version 2 to Version 3 */
+ALTER TABLE games ADD COLUMN uniqueplayers INTEGER DEFAULT 0;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3222,6 +3222,7 @@ namespace server
             vector<uint> seen;
             loopv(savedstatsscores) if(savedstatsscores[i].actortype == A_PLAYER)
             {
+                if((gamemillis / 1000 / 25) >= savedstatsscores[i].timealive) continue;
                 if(savedstatsscores[i].handle[0])
                 {
                     seen.add(savedstatsscores[i].ip);
@@ -3238,7 +3239,6 @@ namespace server
                     }
                 }
             }
-            srvoutf(-3, "%d", unique);
             requestmasterf("stats game %s %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique);
             requestmasterf("stats server %s %s %d\n", escapestring(G(serverdesc)), versionstring, serverport);
             flushmasteroutput();

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3218,7 +3218,28 @@ namespace server
             if(!worthy) return;
             sentstats = true;
             requestmasterf("stats begin\n");
-            requestmasterf("stats game %s %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000);
+            int unique = 0;
+            vector<uint> seen;
+            loopv(savedstatsscores) if(savedstatsscores[i].actortype == A_PLAYER)
+            {
+                if(savedstatsscores[i].handle[0])
+                {
+                    seen.add(savedstatsscores[i].ip);
+                    unique += 1;
+                }
+                else
+                {
+                    bool inseen = false;
+                    loopvj(seen) if(seen[j] == savedstatsscores[i].ip) inseen = true;
+                    if(!inseen)
+                    {
+                        seen.add(savedstatsscores[i].ip);
+                        unique += 1;
+                    }
+                }
+            }
+            srvoutf(-3, "%d", unique);
+            requestmasterf("stats game %s %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique);
             requestmasterf("stats server %s %s %d\n", escapestring(G(serverdesc)), versionstring, serverport);
             flushmasteroutput();
             loopi(numteams(gamemode, mutators))


### PR DESCRIPTION
This will store a `uniqueplayers` column that has the number of players in a game that:
* Were alive at least 25% of the game.
* Have a handle or IP that has not yet been counted.