### PR TITLE
fix efuiattrs init (editing menu)

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -1373,7 +1373,7 @@
             ]
             s0 = "c"
             looplist i [bump env specmap parallax pulse glow] [
-                do [s@i = 1]
+                do [s@i = 0]
             ]
         ]
         guicenter [ guilist [ guilist [
@@ -1395,11 +1395,6 @@
                                 texture $[s@i] (at $texs $i) 0 0 0 0.5 
                                 echo texture $[s@i] (at $texs $i) 0 0 0 0.5 
                             ]
-                            //here we need a workaround to get the newly added texture slot
-                            loopwhile i 1200 [!=s "textures/default.png" (gettexname (+ 2 $i))] [j = (+ 2 $i)]
-                            //apply the new texture to the selection:
-                            echo new slot number $j
-                            settex $j
                         ]
                         guistrut 2
                         guilist [
@@ -1433,6 +1428,7 @@
     efuitypename = "*"
     
     efuireset = [
+        efuiattrs = "*"
         loop i (? $efuitype (getentattr $efuitype) 12) [
             [efuiattr@i] = "*"
         ]


### PR DESCRIPTION
fixes an occasional "unknown alias" line (when opening the ents menu for the first time while an entity is already selected)
also remove texture selection from the experimental shader button, it is likely to pick the wrong slot