### PR TITLE
Show nothumb if the crosshair texture isnt exists....

### DIFF
--- a/config/menus/options.cfg
+++ b/config/menus/options.cfg
@@ -567,7 +567,7 @@ newgui options_ui [
             guilist [
                 guilist [
                     guispring 1
-                    guiimage $crosshairtex [showgui options_xhair] 2 1 [] [crosshairtex "crosshairs/cross-01"]
+                    guiimage $crosshairtex [showgui options_xhair] 2 1 "textures/nothumb" [crosshairtex "crosshairs/cross-01"]
                 ]
                 guilist [
                     guispring 1
@@ -656,6 +656,8 @@ newgui options_ui [
                 guitext "individual shots of clip are displayed in a circular fashion around the crosshair"
             ] "show clips" [
                 guitext "toggles visibility of weapon clip around crosshair"
+            ]  (stringreplace $crosshairtex "crosshairs/" "") [
+                guitext "right click to reset the crosshair texture"
             ]
             cases $guirollovername "showgui options_xhair" [
                 guitext "click to change crosshair texture, opacity and sizing"


### PR DESCRIPTION
When theres not texture you cant reset it, right? ;)

Add
  - description for reseting it with right click
  - nothumb texture if the crosshair texture isnt existing