### PR TITLE
Fix overflow caused by demomaxsize. Update demomaxsize usage doc.

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -26,7 +26,7 @@ setdesc "showaiinfo" "determines how much info is shown for bots;^n0 = hide bot 
 setdesc "demoautoclientsave" "determines if the client automatically saves demos after each match" "<value>"
 setdesc "demolock" "determines who may record demos;^n0 = off, 1 = player, 2 = supporter, 3 = moderator, 4 = operator, 5 = administrator, 6 = developer, 7 = founder" "<value>"
 setdesc "democount" "determines the maximum amount of demo files that may be saved simultaneously on the server (deletes old demos if exceeded)" "<value>"
-setdesc "demomaxsize" "determines the maximum size of individual demo files that may be saved on the server" "<kilobytes>"
+setdesc "demomaxsize" "determines the maximum size of individual demo files that may be saved on the server" "<megabytes>"
 setdesc "demoautorec" "determines if demos are automatically recorded each match" "<value>"
 setdesc "demoautoserversave" "determines if the server automatically saves demos to disk" "<value>"
 setdesc "demoserverkeeptime" "if greater than 0, only keep auto-recorded demos younger than demoserverkeeptime seconds" "<value>"

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -52,7 +52,7 @@ GVAR(IDF_ADMIN, setinfowait, 0, 1000, VAR_MAX);
 
 GVAR(IDF_ADMIN, demolock, 0, PRIV_OPERATOR, PRIV_MAX);
 GVAR(IDF_ADMIN, democount, 1, 10, VAR_MAX);
-GVAR(IDF_ADMIN, demomaxsize, 1, 16, VAR_MAX);
+GVAR(IDF_ADMIN, demomaxsize, 1, 16, (VAR_MAX - 0x10000) >> 20); // Variable is in MB. Size in bytes should fit in int type. See src/game/server.cpp:adddemo()
 GVAR(IDF_ADMIN, demoautorec, 0, 1, 1); // 0 = off, 1 = automatically record demos each match
 GVAR(IDF_ADMIN, demokeep, 0, 0, 1); // 0 = off, 1 = keep demos that don't run to end of match
 GVAR(IDF_ADMIN, demoautoserversave, 0, 0, 1);


### PR DESCRIPTION
Currently usage doc says demomaxsize is in kilobytes, but it's treated as if it's in megabytes and max value for the variable is too big and causes crash if set to big values. Stable is also affected.