### PR TITLE
Add variable to reset checkpoints upon material deaths.

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -338,6 +338,7 @@ setdesc "maxresizescale" "defines the largest scaled size a player can become in
 setdesc "maxcarry" "maximum number of weapons a player can carry, plus pistol and grenades" "<value>"
 setdesc "spawnhealth" "defines the amount of health you spawn with, and the maximum amount of health to which you will regenerate when damaged, assigning this variable a value of 0 or 1 will cause you to die in one hit" "<value>"
 setdesc "zoomtime" "determines how long it takes for the rifle scope to zoom in and out, the rifle uses the primary fire mode unless the scope is fully zoomed in" "<value>"
+setdesc "checkpointspawn" "determines if you will respawn at checkpoints after material deaths" "<value>"
 setdesc "duelmaxqueued" "number of players that can be queued for duel. 0 = any number of players"
 setdesc "survivormaxqueued" "number of players that can be queued for survivor. 0 = any number of players"
 //material

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -307,6 +307,8 @@ namespace game
     VAR(IDF_PERSIST, vanitymodels, 0, 1, 1);
     VAR(IDF_PERSIST, headlessmodels, 0, 1, 1);
     FVAR(IDF_PERSIST, twitchspeed, 0, 8, FVAR_MAX);
+    
+    VAR(0, checkpointspawn, 0, 1, 1);
 
     bool wantsloadoutmenu = false;
     VAR(IDF_PERSIST, showloadoutmenu, 0, 0, 1); // show the loadout menu at the start of a map
@@ -2030,7 +2032,7 @@ namespace game
         if((d == player1 || d->ai) && d->state == CS_ALIVE && d->suicided < 0)
         {
             burn(d, -1, flags);
-            client::addmsg(N_SUICIDE, "ri3", d->clientnum, flags, d->inmaterial);
+            client::addmsg(N_SUICIDE, "ri4", d->clientnum, flags, d->inmaterial, checkpointspawn);
             d->suicided = lastmillis;
         }
     }

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -310,7 +310,7 @@ char msgsizelookup(int msg)
     static const int msgsizes[] =               // size inclusive message token, 0 for variable or not-checked sizes
     {
         N_CONNECT, 0, N_SERVERINIT, 5, N_WELCOME, 2, N_CLIENTINIT, 0, N_POS, 0, N_SPHY, 0, N_TEXT, 0, N_COMMAND, 0, N_ANNOUNCE, 0, N_DISCONNECT, 3,
-        N_SHOOT, 0, N_DESTROY, 0, N_STICKY, 0, N_SUICIDE, 4, N_DIED, 0, N_POINTS, 4, N_DAMAGE, 14, N_SHOTFX, 0,
+        N_SHOOT, 0, N_DESTROY, 0, N_STICKY, 0, N_SUICIDE, 5, N_DIED, 0, N_POINTS, 4, N_DAMAGE, 14, N_SHOTFX, 0,
         N_LOADW, 0, N_TRYSPAWN, 2, N_SPAWNSTATE, 0, N_SPAWN, 0, N_DROP, 0, N_WSELECT, 0,
         N_MAPCHANGE, 0, N_MAPVOTE, 0, N_CLEARVOTE, 0, N_CHECKPOINT, 0, N_ITEMSPAWN, 3, N_ITEMUSE, 0, N_TRIGGER, 0, N_EXECLINK, 3,
         N_PING, 2, N_PONG, 2, N_CLIENTPING, 2, N_TICK, 3, N_ITEMACC, 0, N_SERVMSG, 0, N_GETGAMEINFO, 0, N_GAMEINFO, 0, N_RESUME, 0,

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -113,7 +113,7 @@ namespace server
 
     struct suicideevent : gameevent
     {
-        int flags, material;
+        int flags, material, checkpointspawn;
         void process(clientinfo *ci);
     };
 
@@ -4344,7 +4344,7 @@ namespace server
         ci->state.spree = 0;
         ci->state.deaths++;
         bool kamikaze = dropitems(ci, actor[ci->state.actortype].living ? DROP_DEATH : DROP_EXPIRE);
-        if(m_race(gamemode) && (!m_gsp3(gamemode, mutators) || ci->team == T_ALPHA) && !(flags&HIT_SPEC) && (!flags || ci->state.cpnodes.length() == 1))
+        if(m_race(gamemode) && (!m_gsp3(gamemode, mutators) || ci->team == T_ALPHA) && !(flags&HIT_SPEC) && (!flags || ci->state.cpnodes.length() == 1 || !checkpointspawn))
         { // reset if suicided, hasn't reached another checkpoint yet
             ci->state.cpmillis = 0;
             ci->state.cpnodes.shrink(0);
@@ -5928,12 +5928,13 @@ namespace server
 
                 case N_SUICIDE:
                 {
-                    int lcn = getint(p), flags = getint(p), material = getint(p);
+                    int lcn = getint(p), flags = getint(p), material = getint(p), checkpointspawn = getint(p);
                     clientinfo *cp = (clientinfo *)getinfo(lcn);
                     if(!hasclient(cp, ci)) break;
                     suicideevent *ev = new suicideevent;
                     ev->flags = flags;
                     ev->material = material;
+                    ev->checkpointspawn = checkpointspawn;
                     cp->addevent(ev);
                     break;
                 }


### PR DESCRIPTION
This adds the variable `checkpointspawn` which, when disabled, causes all material deaths to behave like `suicide` and reset checkpoints.

This will solve the small inconvenience of pressing K after respawning at a checkpoint.