### PR TITLE
Send total scores from the master server's statistics database to servers.

### DIFF
--- a/sql/stats/create.sql
+++ b/sql/stats/create.sql
@@ -9,7 +9,8 @@ CREATE TABLE games (
     mode INTEGER,
     mutators INTEGER,
     timeplayed INTEGER,
-    uniqueplayers INTEGER
+    uniqueplayers INTEGER,
+    usetotals INTEGER
 );
 
 CREATE TABLE game_servers (

--- a/sql/stats/upgrade_4.sql
+++ b/sql/stats/upgrade_4.sql
@@ -1,0 +1,2 @@
+/* DB Version 4 to Version 5 */
+ALTER TABLE games ADD COLUMN usetotals INTEGER DEFAULT 0;

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -672,9 +672,9 @@ namespace client
     ICOMMAND(0, getclientfrags, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->frags : -1));
     ICOMMAND(0, getclientdeaths, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->deaths : -1));
 
-    ICOMMAND(0, getclienttotalpoints, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totalpoints : -1));
-    ICOMMAND(0, getclienttotalfrags, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totalfrags : -1));
-    ICOMMAND(0, getclienttotaldeaths, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totaldeaths : -1));
+    ICOMMAND(0, getclienttotalpoints, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totalpoints() : -1));
+    ICOMMAND(0, getclienttotalfrags, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totalfrags() : -1));
+    ICOMMAND(0, getclienttotaldeaths, "i", (int *cn), gameent *d = game::getclient(*cn); intret(d ? d->totaldeaths() : -1));
 
     ICOMMAND(0, getclienttimeplayed, "i", (int *cn), {
         gameent *d = game::getclient(*cn);
@@ -1859,9 +1859,12 @@ namespace client
         d->points = getint(p);
         d->frags = getint(p);
         d->deaths = getint(p);
-        d->totalpoints = getint(p);
-        d->totalfrags = getint(p);
-        d->totaldeaths = getint(p);
+        d->localtotalpoints = getint(p);
+        d->localtotalfrags = getint(p);
+        d->localtotaldeaths = getint(p);
+        d->globaltotalpoints = getint(p);
+        d->globaltotalfrags = getint(p);
+        d->globaltotaldeaths = getint(p);
         d->timeplayed = getint(p);
         d->lasttimeplayed = totalmillis;
         d->health = getint(p);
@@ -2415,7 +2418,7 @@ namespace client
 
                 case N_DIED:
                 {
-                    int vcn = getint(p), deaths = getint(p), tdeaths = getint(p), acn = getint(p), frags = getint(p), tfrags = getint(p), spree = getint(p), style = getint(p), weap = getint(p), flags = getint(p), damage = getint(p), material = getint(p);
+                    int vcn = getint(p), deaths = getint(p), ltdeaths = getint(p), gtdeaths = getint(p), acn = getint(p), frags = getint(p), ltfrags = getint(p), gtfrags = getint(p), spree = getint(p), style = getint(p), weap = getint(p), flags = getint(p), damage = getint(p), material = getint(p);
                     gameent *m = game::getclient(vcn), *v = game::getclient(acn);
                     static vector<gameent *> assist; assist.setsize(0);
                     int count = getint(p);
@@ -2427,9 +2430,11 @@ namespace client
                     }
                     if(!v || !m) break;
                     m->deaths = deaths;
-                    m->totaldeaths = tdeaths;
+                    m->localtotaldeaths = ltdeaths;
+                    m->globaltotaldeaths = gtdeaths;
                     v->frags = frags;
-                    v->totalfrags = tfrags;
+                    v->localtotalfrags = ltfrags;
+                    v->globaltotalfrags = gtfrags;
                     v->spree = spree;
                     game::killed(weap, flags, damage, m, v, assist, style, material);
                     m->lastdeath = lastmillis;
@@ -2439,12 +2444,13 @@ namespace client
 
                 case N_POINTS:
                 {
-                    int acn = getint(p), add = getint(p), points = getint(p), total = getint(p);
+                    int acn = getint(p), add = getint(p), points = getint(p), localtotal = getint(p), globaltotal = getint(p);
                     gameent *v = game::getclient(acn);
                     if(!v) break;
                     v->lastpoints = add;
                     v->points = points;
-                    v->totalpoints = total;
+                    v->localtotalpoints = localtotal;
+                    v->globaltotalpoints = globaltotal;
                     break;
                 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -314,7 +314,7 @@ char msgsizelookup(int msg)
     static const int msgsizes[] =               // size inclusive message token, 0 for variable or not-checked sizes
     {
         N_CONNECT, 0, N_SERVERINIT, 5, N_WELCOME, 2, N_CLIENTINIT, 0, N_POS, 0, N_SPHY, 0, N_TEXT, 0, N_COMMAND, 0, N_ANNOUNCE, 0, N_DISCONNECT, 3,
-        N_SHOOT, 0, N_DESTROY, 0, N_STICKY, 0, N_SUICIDE, 4, N_DIED, 0, N_POINTS, 4, N_DAMAGE, 14, N_SHOTFX, 0,
+        N_SHOOT, 0, N_DESTROY, 0, N_STICKY, 0, N_SUICIDE, 4, N_DIED, 0, N_POINTS, 5, N_DAMAGE, 14, N_SHOTFX, 0,
         N_LOADW, 0, N_TRYSPAWN, 2, N_SPAWNSTATE, 0, N_SPAWN, 0, N_DROP, 0, N_WSELECT, 0,
         N_MAPCHANGE, 0, N_MAPVOTE, 0, N_CLEARVOTE, 0, N_CHECKPOINT, 0, N_ITEMSPAWN, 3, N_ITEMUSE, 0, N_TRIGGER, 0, N_EXECLINK, 3,
         N_PING, 2, N_PONG, 2, N_CLIENTPING, 2, N_TICK, 3, N_ITEMACC, 0, N_SERVMSG, 0, N_GETGAMEINFO, 0, N_GAMEINFO, 0, N_RESUME, 0,

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -545,14 +545,14 @@ struct clientstate
     int health, ammo[W_MAX], entid[W_MAX], colour, model, checkpointspawn;
     int weapselect, weapload[W_MAX], weapshot[W_MAX], weapstate[W_MAX], weapwait[W_MAX], weaptime[W_MAX], prevstate[W_MAX], prevtime[W_MAX];
     int lastdeath, lastspawn, lastpain, lastregen, lastregenamt, lastbuff, lastshoot, lastres[WR_MAX], lastrestime[WR_MAX];
-    int actortype, spawnpoint, ownernum, skill, points, frags, deaths, totalpoints, totalfrags, totaldeaths, spree, lasttimeplayed, timeplayed, cpmillis, cptime, queuepos;
+    int actortype, spawnpoint, ownernum, skill, points, frags, deaths, localtotalpoints, localtotalfrags, localtotaldeaths, globaltotalpoints, globaltotalfrags, globaltotaldeaths, spree, lasttimeplayed, timeplayed, cpmillis, cptime, queuepos;
     bool quarantine;
     string vanity;
     vector<int> loadweap, lastweap, randweap;
     verinfo version;
 
     clientstate() : colour(0), model(0), checkpointspawn(1), weapselect(W_CLAW), lastdeath(0), lastspawn(0), lastpain(0), lastregen(0), lastregenamt(0), lastbuff(0), lastshoot(0),
-        actortype(A_PLAYER), spawnpoint(-1), ownernum(-1), skill(0), points(0), frags(0), deaths(0), totalpoints(0), totalfrags(0), totaldeaths(0), spree(0), lasttimeplayed(0), timeplayed(0),
+        actortype(A_PLAYER), spawnpoint(-1), ownernum(-1), skill(0), points(0), frags(0), deaths(0), localtotalpoints(0), localtotalfrags(0), localtotaldeaths(0), globaltotalpoints(0), globaltotalfrags(0), globaltotaldeaths(0), spree(0), lasttimeplayed(0), timeplayed(0),
         cpmillis(0), cptime(0), queuepos(-1), quarantine(false)
     {
         setvanity();
@@ -562,6 +562,10 @@ struct clientstate
         resetresidual();
     }
     ~clientstate() {}
+
+    int totalpoints() { return localtotalpoints + globaltotalpoints; }
+    int totalfrags() { return localtotalfrags + globaltotalfrags; }
+    int totaldeaths() { return localtotaldeaths + globaltotaldeaths; }
 
     bool setvanity(const char *v = "")
     {
@@ -793,12 +797,12 @@ struct clientstate
     float scoretime(bool update = true)
     {
         if(update) updatetimeplayed();
-        return totalpoints/float(max(timeplayed, 1));
+        return localtotalpoints/float(max(timeplayed, 1));
     }
 
     float kdratio(bool total = true)
     {
-        if(total) return totalfrags >= totaldeaths ? (totalfrags/float(max(totaldeaths, 1))) : -(totaldeaths/float(max(totalfrags, 1)));
+        if(total) return totalfrags() >= totaldeaths() ? (totalfrags()/float(max(totaldeaths(), 1))) : -(totaldeaths()/float(max(totalfrags(), 1)));
         return frags >= deaths ? (frags/float(max(deaths, 1))) : -(deaths/float(max(frags, 1)));
     }
 

--- a/src/game/gamemode.h
+++ b/src/game/gamemode.h
@@ -283,6 +283,7 @@ extern mutstypes mutstype[];
 #define m_impulsemeter(a,b) (m_ra_endurance(a, b) || !m_freestyle(a, b))
 #define m_nopoints(a,b)     (m_duke(a, b) || m_bb_hold(a, b) || m_race(a))
 #define m_points(a,b)       (!m_nopoints(a, b))
+#define m_usetotals(a,b)    (!m_race(a))
 
 #define m_weapon(at,a,b)    (m_medieval(a, b) ? AA(at, weaponmedieval) : (m_kaboom(a, b) ? AA(at, weaponkaboom) : (m_insta(a, b) ? AA(at, weaponinsta) : (m_race(a) && !m_ra_gauntlet(a, b) ? AA(at, weaponrace) : (m_dm_gladiator(a, b) ? AA(at, weapongladiator) : AA(at, weaponspawn))))))
 #define m_delay(at,a,b,c)   ((m_play(a) || at >= A_ENEMY) && !m_duke(a,b) ? int((m_race(a) ? (!m_ra_gauntlet(a, b) || c == T_ALPHA ? AA(at, spawndelayrace) : AA(at, spawndelaygauntlet)) : (m_bomber(a) ? AA(at, spawndelaybomber) : (m_defend(a) ? AA(at, spawndelaydefend) : (m_capture(a) ? AA(at, spawndelaycapture) : AA(at, spawndelay)))))*(m_insta(a, b) ? AA(at, spawndelayinstascale) : 1.f)) : 0)

--- a/src/game/scoreboard.cpp
+++ b/src/game/scoreboard.cpp
@@ -575,7 +575,7 @@ namespace hud
                                             ownerbg;
                                             if(scoretotalpoints)
                                             {
-                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->points, o->totalpoints)));
+                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->points, o->totalpoints())));
                                             }
                                             else uicenter(g, uipad(g, 0.5f, g.textf("%d", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->points)));
                                         }));
@@ -608,7 +608,7 @@ namespace hud
                                             ownerbg;
                                             if(scoretotalfrags)
                                             {
-                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->frags, o->totalfrags)));
+                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->frags, o->totalfrags())));
                                             }
                                             else uicenter(g, uipad(g, 0.5f, g.textf("%d", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->frags)));
                                         }));
@@ -625,7 +625,7 @@ namespace hud
                                             ownerbg;
                                             if(scoretotaldeaths)
                                             {
-                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->deaths, o->totaldeaths)));
+                                                uicenter(g, uipad(g, 0.5f, g.textf("%d (%d)", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->deaths, o->totaldeaths())));
                                             }
                                             else uicenter(g, uipad(g, 0.5f, g.textf("%d", ownerfgc, NULL, 0, -1, false, NULL, 0xFFFFFF, o->deaths)));
                                         }));

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2801,7 +2801,7 @@ namespace server
         if(give)
         {
             ci->points += points;
-            sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
+            sendf(-1, 1, "ri6", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
             if(team && m_team(gamemode, mutators) && m_dm(gamemode))
             {
                 score &ts = teamscore(ci->team);
@@ -2809,7 +2809,7 @@ namespace server
                 sendf(-1, 1, "ri3", N_SCORE, ts.team, ts.total);
             }
         }
-        else if(points) sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
+        else if(points) sendf(-1, 1, "ri6", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
     }
 
     void savescore(clientinfo *ci)
@@ -3320,7 +3320,8 @@ namespace server
                     }
                 }
             }
-            requestmasterf("stats game %s %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique);
+            requestmasterf("stats game %s %d %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique, m_usetotals(gamemode, mutators));
+            flushmasteroutput();
             requestmasterf("stats server %s %s %d\n", escapestring(G(serverdesc)), versionstring, serverport);
             flushmasteroutput();
             loopi(numteams(gamemode, mutators))

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -460,7 +460,7 @@ namespace server
     {
         uint ip;
         string name, handle;
-        int points, frags, deaths, totalpoints, totalfrags, totaldeaths, spree, rewards, timeplayed, timealive, timeactive, shotdamage, damage, cptime, actortype;
+        int points, frags, deaths, localtotalpoints, localtotalfrags, localtotaldeaths, globaltotalpoints, globaltotalfrags, globaltotaldeaths, spree, rewards, timeplayed, timealive, timeactive, shotdamage, damage, cptime, actortype;
         int warnings[WARN_MAX][2];
         vector<teamkill> teamkills;
         weaponstats weapstats[W_MAX];
@@ -474,9 +474,12 @@ namespace server
             points = ci->points;
             frags = ci->frags;
             deaths = ci->deaths;
-            totalpoints = ci->totalpoints;
-            totalfrags = ci->totalfrags;
-            totaldeaths = ci->totaldeaths;
+            localtotalpoints = ci->localtotalpoints;
+            localtotalfrags = ci->localtotalfrags;
+            localtotaldeaths = ci->localtotaldeaths;
+            globaltotalpoints = ci->globaltotalpoints;
+            globaltotalfrags = ci->globaltotalfrags;
+            globaltotaldeaths = ci->globaltotaldeaths;
             spree = ci->spree;
             rewards = ci->rewards[0];
             timeplayed = ci->timeplayed;
@@ -500,9 +503,12 @@ namespace server
             ci->points = points;
             ci->frags = frags;
             ci->deaths = deaths;
-            ci->totalpoints = totalpoints;
-            ci->totalfrags = totalfrags;
-            ci->totaldeaths = totaldeaths;
+            ci->localtotalpoints = localtotalpoints;
+            ci->localtotalfrags = localtotalfrags;
+            ci->localtotaldeaths = localtotaldeaths;
+            ci->globaltotalpoints = globaltotalpoints;
+            ci->globaltotalfrags = globaltotalfrags;
+            ci->globaltotaldeaths = globaltotaldeaths;
             ci->spree = spree;
             ci->rewards[0] = rewards;
             ci->timeplayed = timeplayed;
@@ -1612,13 +1618,13 @@ namespace server
                             switch(G(teambalancestyle))
                             {
                                 case 1: if(id < 0 || tc[i][id]->timeplayed > cp->timeplayed) id = j; break;
-                                case 2: if(id < 0 || tc[i][id]->totalpoints > cp->totalpoints) id = j; break;
-                                case 3: if(id < 0 || tc[i][id]->totalfrags > cp->totalfrags) id = j; break;
+                                case 2: if(id < 0 || tc[i][id]->totalpoints() > cp->totalpoints()) id = j; break;
+                                case 3: if(id < 0 || tc[i][id]->totalfrags() > cp->totalfrags()) id = j; break;
                                 case 4: if(id < 0 || tc[i][id]->scoretime(false) > cp->scoretime(false)) id = j; break;
                                 case 5: if(id < 0 || tc[i][id]->kdratio() > cp->kdratio()) id = j; break;
                                 case 6: if(id < 0 || tc[i][id]->timeplayed < cp->timeplayed) id = j; break;
-                                case 7: if(id < 0 || tc[i][id]->totalpoints < cp->totalpoints) id = j; break;
-                                case 8: if(id < 0 || tc[i][id]->totalfrags < cp->totalfrags) id = j; break;
+                                case 7: if(id < 0 || tc[i][id]->totalpoints() < cp->totalpoints()) id = j; break;
+                                case 8: if(id < 0 || tc[i][id]->totalfrags() < cp->totalfrags()) id = j; break;
                                 case 9: if(id < 0 || tc[i][id]->scoretime(false) < cp->scoretime(false)) id = j; break;
                                 case 10: if(id < 0 || tc[i][id]->kdratio() < cp->kdratio()) id = j; break;
                                 case 0: default: if(id < 0) id = j; break;
@@ -2175,7 +2181,7 @@ namespace server
         int spawn = pickspawn(ci);
         ci->spawnstate(gamemode, mutators, weap, health);
         ci->updatetimeplayed();
-        sendf(ci->clientnum, 1, "ri9i5v", N_SPAWNSTATE, ci->clientnum, spawn, ci->state, ci->points, ci->frags, ci->deaths, ci->totalpoints, ci->totalfrags, ci->totaldeaths, ci->timeplayed, ci->health, ci->cptime, ci->weapselect, W_MAX, &ci->ammo[0]);
+        sendf(ci->clientnum, 1, "ri9i8v", N_SPAWNSTATE, ci->clientnum, spawn, ci->state, ci->points, ci->frags, ci->deaths, ci->localtotalpoints, ci->localtotalfrags, ci->localtotaldeaths, ci->globaltotalpoints, ci->globaltotalfrags, ci->globaltotaldeaths, ci->timeplayed, ci->health, ci->cptime, ci->weapselect, W_MAX, &ci->ammo[0]);
         ci->lastspawn = gamemillis;
     }
 
@@ -2187,9 +2193,12 @@ namespace server
         putint(p, ci->points);
         putint(p, ci->frags);
         putint(p, ci->deaths);
-        putint(p, ci->totalpoints);
-        putint(p, ci->totalfrags);
-        putint(p, ci->totaldeaths);
+        putint(p, ci->localtotalpoints);
+        putint(p, ci->localtotalfrags);
+        putint(p, ci->localtotaldeaths);
+        putint(p, ci->globaltotalpoints);
+        putint(p, ci->globaltotalfrags);
+        putint(p, ci->globaltotaldeaths);
         putint(p, ci->timeplayed);
         putint(p, ci->health);
         putint(p, ci->cptime);
@@ -2788,11 +2797,11 @@ namespace server
 
     void givepoints(clientinfo *ci, int points, bool give, bool team = true)
     {
-        ci->totalpoints += points;
+        ci->localtotalpoints += points;
         if(give)
         {
             ci->points += points;
-            sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->totalpoints);
+            sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
             if(team && m_team(gamemode, mutators) && m_dm(gamemode))
             {
                 score &ts = teamscore(ci->team);
@@ -2800,7 +2809,7 @@ namespace server
                 sendf(-1, 1, "ri3", N_SCORE, ts.team, ts.total);
             }
         }
-        else if(points) sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->totalpoints);
+        else if(points) sendf(-1, 1, "ri5", N_POINTS, ci->clientnum, points, ci->points, ci->localtotalpoints, ci->globaltotalpoints);
     }
 
     void savescore(clientinfo *ci)
@@ -2851,8 +2860,8 @@ namespace server
             switch(G(teambalancestyle))
             {
                 case 1: case 6: csk = ci->timeplayed; break;
-                case 2: case 7: csk = ci->totalpoints; break;
-                case 3: case 8: csk = ci->totalfrags; break;
+                case 2: case 7: csk = ci->totalpoints(); break;
+                case 3: case 8: csk = ci->totalfrags(); break;
                 case 4: case 9: csk = ci->scoretime(); break;
                 case 5: case 10: csk = ci->kdratio(); break;
                 case 0: default: break;
@@ -2865,8 +2874,8 @@ namespace server
                 switch(G(teambalancestyle))
                 {
                     case 1: case 6: psk = cp->timeplayed; break;
-                    case 2: case 7: psk = cp->totalpoints; break;
-                    case 3: case 8: psk = cp->totalfrags; break;
+                    case 2: case 7: psk = cp->totalpoints(); break;
+                    case 3: case 8: psk = cp->totalfrags(); break;
                     case 4: case 9: psk = cp->scoretime(); break;
                     case 5: case 10: psk = cp->kdratio(); break;
                     case 0: default: break;
@@ -2977,8 +2986,8 @@ namespace server
                     switch(G(teambalancestyle))
                     {
                         case 1: case 6: ts.score += cp->timeplayed; break;
-                        case 2: case 7: ts.score += cp->totalpoints; break;
-                        case 3: case 8: ts.score += cp->totalfrags; break;
+                        case 2: case 7: ts.score += cp->totalpoints(); break;
+                        case 3: case 8: ts.score += cp->totalfrags(); break;
                         case 4: case 9: ts.score += cp->scoretime(); break;
                         case 5: case 10: ts.score += cp->kdratio(); break;
                         case 0: default: ts.score += 1; break;
@@ -3819,7 +3828,7 @@ namespace server
     void sendresume(clientinfo *ci)
     {
         ci->updatetimeplayed();
-        sendf(-1, 1, "ri9i4vi", N_RESUME, ci->clientnum, ci->state, ci->points, ci->frags, ci->deaths, ci->totalpoints, ci->totalfrags, ci->totaldeaths, ci->timeplayed, ci->health, ci->cptime, ci->weapselect, W_MAX, &ci->ammo[0], -1);
+        sendf(-1, 1, "ri9i7vi", N_RESUME, ci->clientnum, ci->state, ci->points, ci->frags, ci->deaths, ci->localtotalpoints, ci->localtotalfrags, ci->localtotaldeaths, ci->globaltotalpoints, ci->globaltotalfrags, ci->globaltotaldeaths, ci->timeplayed, ci->health, ci->cptime, ci->weapselect, W_MAX, &ci->ammo[0], -1);
     }
 
     void putinitclient(clientinfo *ci, packetbuf &p)
@@ -4197,7 +4206,7 @@ namespace server
             if(m != v && (!m_team(gamemode, mutators) || m->team != v->team))
             {
                 v->frags++;
-                v->totalfrags++;
+                v->localtotalfrags++;
                 if(statalt) v->weapstats[statweap].frags2++;
                 else v->weapstats[statweap].frags1++;
             }
@@ -4307,13 +4316,13 @@ namespace server
                 else if(v->actortype < A_ENEMY) givepoints(v, pointvalue, m_points(gamemode, mutators), true);
             }
             m->deaths++;
-            m->totaldeaths++;
+            m->localtotaldeaths++;
             m->rewards[1] = 0;
             dropitems(m, actor[m->actortype].living ? DROP_DEATH : DROP_EXPIRE);
             static vector<int> dmglog;
             dmglog.setsize(0);
             gethistory(m, v, gamemillis, dmglog, true, m_dm_oldschool(gamemode, mutators) ? 0 : 1);
-            sendf(-1, 1, "ri9i5v", N_DIED, m->clientnum, m->deaths, m->totaldeaths, v->clientnum, v->frags, v->totalfrags, v->spree, style, weap, realflags, realdamage, material, dmglog.length(), dmglog.length(), dmglog.getbuf());
+            sendf(-1, 1, "ri9i7v", N_DIED, m->clientnum, m->deaths, m->localtotaldeaths, m->globaltotaldeaths, v->clientnum, v->frags, v->localtotalfrags, v->globaltotalfrags, v->spree, style, weap, realflags, realdamage, material, dmglog.length(), dmglog.length(), dmglog.getbuf());
             m->position.setsize(0);
             if(smode) smode->died(m, v);
             mutate(smuts, mut->died(m, v));
@@ -4371,7 +4380,7 @@ namespace server
         }
         ci->spree = 0;
         ci->deaths++;
-        ci->totaldeaths++;
+        ci->localtotaldeaths++;
         bool kamikaze = dropitems(ci, actor[ci->actortype].living ? DROP_DEATH : DROP_EXPIRE);
         if(ci->actortype < A_ENEMY && m_race(gamemode) && (!m_ra_gauntlet(gamemode, mutators) || ci->team == T_ALPHA) && !(flags&HIT_SPEC) && (!flags || ci->cpnodes.length() == 1 || !ci->checkpointspawn))
         { // reset if suicided, hasn't reached another checkpoint yet
@@ -4406,7 +4415,7 @@ namespace server
         }
         static vector<int> dmglog; dmglog.setsize(0);
         gethistory(ci, ci, gamemillis, dmglog, true, m_dm_oldschool(gamemode, mutators) ? 0 : 1);
-        sendf(-1, 1, "ri9i5v", N_DIED, ci->clientnum, ci->deaths, ci->totaldeaths, ci->clientnum, ci->frags, ci->totalfrags, 0, 0, -1, flags, ci->health*2, material, dmglog.length(), dmglog.length(), dmglog.getbuf());
+        sendf(-1, 1, "ri9i7v", N_DIED, ci->clientnum, ci->deaths, ci->localtotaldeaths, ci->globaltotaldeaths, ci->clientnum, ci->frags, ci->localtotalfrags, ci->globaltotalfrags, 0, 0, -1, flags, ci->health*2, material, dmglog.length(), dmglog.length(), dmglog.getbuf());
         ci->position.setsize(0);
         if(smode) smode->died(ci, NULL);
         mutate(smuts, mut->died(ci, NULL));


### PR DESCRIPTION
When a player authenticates, the master server will send totals from the player's last `masterbalancegames` number of games. The server will use these totals in balancing.

These things may need work or comment before merging:

* Players who have played the full `masterbalancegames` will have a much larger total than an unauthed player or new player. One solution to this is to weight the totals according to how many games were played.
* The `masterbalancegames` value itself was added so that only the player's relatively recent skill would be used in balancing, very old games would not affect it. There may be a better value for this, currently it is `200`.
* Each handle's totals information is retrieved the first time a player auths on a server, and that server will keep the same information until restart. This means that once a player has authed, only the previous totals and totals from that server will be counted there, games on other servers will not be counted until the server restarts. This needs changed to allow updating the totals information while not doubly counting games in the statistics that were submitted by the server.

Closes #494