### PR TITLE
Send totals statistics to servers for balancing.

### DIFF
--- a/sql/stats/upgrade_4.sql
+++ b/sql/stats/upgrade_4.sql
@@ -1,0 +1,2 @@
+/* DB Version 4 to Version 5 */
+ALTER TABLE games ADD COLUMN usetotals INTEGER DEFAULT 0;

--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -79,9 +79,8 @@ struct masterclient
     {
         ulong id;
         statstring map;
-        int mode, mutators, timeplayed;
+        int mode, mutators, timeplayed, usetotals;
         time_t time;
-        bool usetotals;
 
         statstring desc, version;
         int port;
@@ -210,8 +209,7 @@ struct masterclient
             map[0] = desc[0] = version[0] = '\0';
             mode = mutators = -1;
             timeplayed = 0;
-            unique = time = 0;
-            usetotals = false;
+            unique = time = usetotals = 0;
             port = 0;
             teams.shrink(0);
             players.shrink(0);

--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -10,7 +10,7 @@
 #include <enet/time.h>
 #include <sqlite3.h>
 
-#define STATSDB_VERSION 4
+#define STATSDB_VERSION 5
 #define STATSDB_RETRYTIME (5*1000)
 #define MASTER_LIMIT 4096
 #define CLIENT_TIME (60*1000)
@@ -81,6 +81,7 @@ struct masterclient
         statstring map;
         int mode, mutators, timeplayed;
         time_t time;
+        bool usetotals;
 
         statstring desc, version;
         int port;
@@ -210,6 +211,7 @@ struct masterclient
             mode = mutators = -1;
             timeplayed = 0;
             unique = time = 0;
+            usetotals = false;
             port = 0;
             teams.shrink(0);
             players.shrink(0);
@@ -341,6 +343,24 @@ void loadstatsdb()
     conoutf("statistics database loaded");
 }
 
+int playertotalstat(const char *handle, const char *stat)
+{
+    int ret = 0;
+    sqlite3_stmt *stmt;
+    defformatstring(sql, "SELECT SUM(%s) FROM (SELECT %s FROM game_players WHERE handle = ? AND game IN (SELECT id FROM games WHERE usetotals = 1))", stat, stat);
+
+    checkstatsdb(sqlite3_prepare_v2(statsdb, sql, -1, &stmt, 0));
+    checkstatsdb(sqlite3_bind_text(stmt, 1, handle, strlen(handle), SQLITE_TRANSIENT));
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        ret = sqlite3_column_int(stmt, 0);
+    }
+
+    sqlite3_finalize(stmt);
+    return ret;
+}
+
+
 void masterout(masterclient &c, const char *msg, int len = 0)
 {
     if(!len) len = strlen(msg);
@@ -366,13 +386,14 @@ void savestats(masterclient &c)
     if(rc == SQLITE_BUSY) return;
     else checkstatsdb(rc, errmsg);
 
-    statsdbexecf("INSERT INTO games VALUES (NULL, %d, %Q, %d, %d, %d, %d)",
+    statsdbexecf("INSERT INTO games VALUES (NULL, %d, %Q, %d, %d, %d, %d, %d)",
         c.stats.time,
         c.stats.map,
         c.stats.mode,
         c.stats.mutators,
         c.stats.timeplayed,
-        c.stats.unique
+        c.stats.unique,
+        c.stats.usetotals
     );
     c.stats.id = (ulong)sqlite3_last_insert_rowid(statsdb);
 
@@ -476,6 +497,17 @@ void savestats(masterclient &c)
     masteroutf(c, "stats success \"game statistics recorded, id \fc%lu\"\n", c.stats.id);
     c.instats = false;
     c.wantstats = false;
+}
+
+void sendauthstats(masterclient &c, const char *name)
+{
+    masteroutf(c, "authstats \"%s\" %d %d %d %d %d\n", name,
+        playertotalstat(name, "score"),
+        playertotalstat(name, "frags"),
+        playertotalstat(name, "deaths"),
+        playertotalstat(name, "timealive"),
+        playertotalstat(name, "timeactive")
+    );
 }
 
 bool setuppingsocket(ENetAddress *address)
@@ -636,6 +668,7 @@ void confauth(masterclient &c, uint id, const char *val)
         if(checkchallenge(val, c.authreqs[i].answer))
         {
             masteroutf(c, "succauth %u \"%s\" \"%s\"\n", id, c.authreqs[i].user->name, c.authreqs[i].user->flags);
+            sendauthstats(c, c.authreqs[i].user->name);
             conoutf("succeeded '%s' [%s] (%u) from %s on server %s\n", c.authreqs[i].user->name, c.authreqs[i].user->flags, id, c.authreqs[i].hostname, ip);
         }
         else
@@ -888,6 +921,7 @@ bool checkmasterclientinput(masterclient &c)
                     c.stats.timeplayed = atoi(w[5]);
                     c.stats.time = currenttime;
                     c.stats.unique = atoi(w[6]);
+                    c.stats.usetotals = atoi(w[7]);
                 }
                 else if(!strcmp(w[1], "server"))
                 {
@@ -980,6 +1014,7 @@ bool checkmasterclientinput(masterclient &c)
             if(!strcmp(w[0], "reqserverauth")) { reqserverauth(c, w[1]); found = true; }
             if(!strcmp(w[0], "confauth")) { confauth(c, uint(atoi(w[1])), w[2]); found = true; }
             if(!strcmp(w[0], "confserverauth")) { confserverauth(c, w[1]); found = true; }
+            if(!strcmp(w[0], "reqauthstats")) { sendauthstats(c, w[1]); found = true; }
         }
         if(w[0] && *w[0] && !found)
         {

--- a/src/game/auth.h
+++ b/src/game/auth.h
@@ -96,6 +96,13 @@ namespace auth
         return NULL;
     }
 
+    clientinfo *findauthhandle(const char *handle)
+    {
+        loopv(clients) if(!strcmp(clients[i]->handle, handle)) return clients[i];
+        loopv(connects) if(!strcmp(connects[i]->handle, handle)) return connects[i];
+        return NULL;
+    }
+
     void reqserverauth()
     {
         if(connectedmaster() && *serveraccountpass && serverauthconnect && !hasauth)
@@ -380,6 +387,16 @@ namespace auth
         else if(!strcmp(w[0], "echo")) { conoutf("master server reply: %s", w[1]); }
         else if(!strcmp(w[0], "failauth")) authfailed((uint)(atoi(w[1])));
         else if(!strcmp(w[0], "succauth")) authsucceeded((uint)(atoi(w[1])), w[2], w[3]);
+        else if(!strcmp(w[0], "authstats"))
+        {
+            clientinfo *ci = findauthhandle(w[1]);
+            if(ci)
+            {
+                ci->totalpoints = ci->localtotalpoints + atoi(w[2]);
+                ci->totalfrags = ci->localtotalfrags + atoi(w[3]);
+                ci->totaldeaths = ci->localtotaldeaths + atoi(w[4]);
+            }
+        }
         else if(!strcmp(w[0], "failserverauth")) serverauthfailed();
         else if(!strcmp(w[0], "succserverauth")) serverauthsucceeded(w[1], w[2]);
         else if(!strcmp(w[0], "chalauth")) authchallenged((uint)(atoi(w[1])), w[2]);

--- a/src/game/gamemode.h
+++ b/src/game/gamemode.h
@@ -282,6 +282,7 @@ extern mutstypes mutstype[];
 #define m_impulsemeter(a,b) (m_ra_endurance(a, b) || !m_freestyle(a, b))
 #define m_nopoints(a,b)     (m_duke(a, b) || m_bb_hold(a, b) || m_race(a))
 #define m_points(a,b)       (!m_nopoints(a, b))
+#define m_usetotals(a,b)    (!m_race(a))
 
 #define m_weapon(at,a,b)    (m_medieval(a, b) ? AA(at, weaponmedieval) : (m_kaboom(a, b) ? AA(at, weaponkaboom) : (m_insta(a, b) ? AA(at, weaponinsta) : (m_race(a) && !m_ra_gauntlet(a, b) ? AA(at, weaponrace) : (m_dm_gladiator(a, b) ? AA(at, weapongladiator) : AA(at, weaponspawn))))))
 #define m_delay(at,a,b,c)   ((m_play(a) || at >= A_ENEMY) && !m_duke(a,b) ? int((m_race(a) ? (!m_ra_gauntlet(a, b) || c == T_ALPHA ? AA(at, spawndelayrace) : AA(at, spawndelaygauntlet)) : (m_bomber(a) ? AA(at, spawndelaybomber) : (m_defend(a) ? AA(at, spawndelaydefend) : (m_capture(a) ? AA(at, spawndelaycapture) : AA(at, spawndelay)))))*(m_insta(a, b) ? AA(at, spawndelayinstascale) : 1.f)) : 0)

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -508,6 +508,9 @@ namespace server
             ci->localtotalpoints = localtotalpoints;
             ci->localtotalfrags = localtotalfrags;
             ci->localtotaldeaths = localtotaldeaths;
+            ci->totalpoints = localtotalpoints;
+            ci->totalfrags = localtotalfrags;
+            ci->totaldeaths = localtotaldeaths;
             ci->spree = spree;
             ci->rewards[0] = rewards;
             ci->timeplayed = timeplayed;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -262,7 +262,8 @@ namespace server
     struct servstate : baseent, clientstate
     {
         int rewards[2], shotdamage, damage, lasttimewielded, lasttimeloadout[W_ALL], aireinit,
-            lastresowner[WR_MAX], lasttimealive, timealive, lasttimeactive, timeactive, lastresweapon[WR_MAX], lasthurt;
+            lastresowner[WR_MAX], lasttimealive, timealive, lasttimeactive, timeactive, lastresweapon[WR_MAX], lasthurt,
+            localtotalpoints, localtotalfrags, localtotaldeaths;
         bool lastresalt[W_MAX];
         projectilestate dropped, weapshots[W_MAX][2];
         vector<int> fraglog, fragmillis, cpnodes, chatmillis;
@@ -276,7 +277,7 @@ namespace server
 
         int warnings[WARN_MAX][2];
 
-        servstate() : lasttimewielded(0), aireinit(0), lasttimealive(0), timealive(0), timeactive(0), lasthurt(0)
+        servstate() : lasttimewielded(0), aireinit(0), lasttimealive(0), timealive(0), timeactive(0), lasthurt(0), localtotalpoints(0), localtotalfrags(0), localtotaldeaths(0)
         {
             loopi(WARN_MAX) loopj(2) warnings[i][j] = 0;
             loopi(W_ALL) lasttimeloadout[i] = 0;
@@ -416,6 +417,10 @@ namespace server
             if(!change) lastteam = T_NEUTRAL;
             team = swapteam = T_NEUTRAL;
             clientmap[0] = '\0';
+            if (handle[0])
+            {
+                requestmasterf("reqauthstats \"%s\"\n", handle);
+            }
         }
 
         void cleanclipboard(bool fullclean = true)
@@ -460,7 +465,7 @@ namespace server
     {
         uint ip;
         string name, handle;
-        int points, frags, deaths, totalpoints, totalfrags, totaldeaths, spree, rewards, timeplayed, timealive, timeactive, shotdamage, damage, cptime, actortype;
+        int points, frags, deaths, localtotalpoints, localtotalfrags, localtotaldeaths, spree, rewards, timeplayed, timealive, timeactive, shotdamage, damage, cptime, actortype;
         int warnings[WARN_MAX][2];
         vector<teamkill> teamkills;
         weaponstats weapstats[W_MAX];
@@ -474,9 +479,9 @@ namespace server
             points = ci->points;
             frags = ci->frags;
             deaths = ci->deaths;
-            totalpoints = ci->totalpoints;
-            totalfrags = ci->totalfrags;
-            totaldeaths = ci->totaldeaths;
+            localtotalpoints = ci->localtotalpoints;
+            localtotalfrags = ci->localtotalfrags;
+            localtotaldeaths = ci->localtotaldeaths;
             spree = ci->spree;
             rewards = ci->rewards[0];
             timeplayed = ci->timeplayed;
@@ -500,9 +505,9 @@ namespace server
             ci->points = points;
             ci->frags = frags;
             ci->deaths = deaths;
-            ci->totalpoints = totalpoints;
-            ci->totalfrags = totalfrags;
-            ci->totaldeaths = totaldeaths;
+            ci->localtotalpoints = localtotalpoints;
+            ci->localtotalfrags = localtotalfrags;
+            ci->localtotaldeaths = localtotaldeaths;
             ci->spree = spree;
             ci->rewards[0] = rewards;
             ci->timeplayed = timeplayed;
@@ -2789,6 +2794,7 @@ namespace server
     void givepoints(clientinfo *ci, int points, bool give, bool team = true)
     {
         ci->totalpoints += points;
+        ci->localtotalpoints += points;
         if(give)
         {
             ci->points += points;
@@ -3288,6 +3294,13 @@ namespace server
                 }
             }
             if(!worthy) return;
+
+            loopv(clients) {
+                clients[i]->localtotalpoints -= clients[i]->points;
+                clients[i]->localtotalfrags -= clients[i]->frags;
+                clients[i]->localtotaldeaths -= clients[i]->deaths;
+            }
+
             sentstats = true;
             requestmasterf("stats begin\n");
             int unique = 0;
@@ -3311,7 +3324,8 @@ namespace server
                     }
                 }
             }
-            requestmasterf("stats game %s %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique);
+            requestmasterf("stats game %s %d %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique, m_usetotals(gamemode, mutators));
+            flushmasteroutput();
             requestmasterf("stats server %s %s %d\n", escapestring(G(serverdesc)), versionstring, serverport);
             flushmasteroutput();
             loopi(numteams(gamemode, mutators))
@@ -4198,6 +4212,7 @@ namespace server
             {
                 v->frags++;
                 v->totalfrags++;
+                v->localtotalfrags++;
                 if(statalt) v->weapstats[statweap].frags2++;
                 else v->weapstats[statweap].frags1++;
             }
@@ -4308,6 +4323,7 @@ namespace server
             }
             m->deaths++;
             m->totaldeaths++;
+            m->localtotaldeaths++;
             m->rewards[1] = 0;
             dropitems(m, actor[m->actortype].living ? DROP_DEATH : DROP_EXPIRE);
             static vector<int> dmglog;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -420,6 +420,7 @@ namespace server
             if (handle[0])
             {
                 requestmasterf("reqauthstats \"%s\"\n", handle);
+                flushmasteroutput();
             }
         }
 

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3299,7 +3299,8 @@ namespace server
             }
             if(!worthy) return;
 
-            loopv(clients) {
+            loopv(clients)
+            {
                 clients[i]->localtotalpoints -= clients[i]->points;
                 clients[i]->localtotalfrags -= clients[i]->frags;
                 clients[i]->localtotaldeaths -= clients[i]->deaths;
@@ -3328,7 +3329,7 @@ namespace server
                     }
                 }
             }
-            requestmasterf("stats game %s %d %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique, m_usetotals(gamemode, mutators));
+            requestmasterf("stats game %s %d %d %d %d %d\n", escapestring(smapname), gamemode, mutators, gamemillis/1000, unique, m_usetotals(gamemode, mutators) ? 1 : 0);
             flushmasteroutput();
             requestmasterf("stats server %s %s %d\n", escapestring(G(serverdesc)), versionstring, serverport);
             flushmasteroutput();


### PR DESCRIPTION
Here is a reworked, simpler version of #498.
Servers request totals from the master server upon authentication and map change.
Local scores are kept for servers that do not send statistics.

Closes #494 