### PR TITLE
Fix numerical values of mutators in example server config

### DIFF
--- a/doc/examples/servinit.cfg
+++ b/doc/examples/servinit.cfg
@@ -83,17 +83,18 @@ if (= $rehashing 0) [
 // sv_defaultmuts 0 // determines the default mutators to use when server is idle
 // sv_rotatemutsfilter 258 // determines the mutators which are allowed to be generated when there are no votes and the server creates a random game
 //   mutators are set as a bitmask, where each numbered bit has a corresponding alias (for example, 258 can be expressed as " (+ $mutsbitffa $mutsbitclassic) "):
-//        1 $mutsbitmulti         128 $mutsbitsurvivor
-//        2 $mutsbitffa           256 $mutsbitclassic
-//        4 $mutsbitcoop          512 $mutsbitonslaught
-//        8 $mutsbitinstagib     1024 $mutsbitfreestyle
-//       16 $mutsbitmedieval     2048 $mutsbitvampire
-//       32 $mutsbitkaboom       4096 $mutsbithard
-//       64 $mutsbitduel         8192 $mutsbitresize
-//    16384 $mutsbitgsp1 (quick capture the flag, quick defend and control, hold bomber ball, marathon time trial)
-//    32768 $mutsbitgsp2 (defend capture the flag, king defend and control, basket bomber ball, endurance time trial)
-//    65536 $mutsbitgsp3 (protect capture the flag, attack bomber ball, gauntlet time trial)
-//   131071 $mutsbitall (all of the bits added together)
+//        1 $mutsbitmulti         256 $mutsbitclassic
+//        2 $mutsbitffa           512 $mutsbitonslaught
+//        4 $mutsbitcoop         1024 $mutsbitfreestyle
+//        8 $mutsbitinstagib     2048 $mutsbitvampire
+//       16 $mutsbitmedieval     4096 $mutsbitresize
+//       32 $mutsbitkaboom       8192 $mutsbithard
+//       64 $mutsbitduel        16384 $mutsbitbasic
+//      128 $mutsbitsurvivor
+//    32768 $mutsbitgsp1 (quick capture the flag, quick defend and control, hold bomber ball, marathon time trial)
+//    65536 $mutsbitgsp2 (defend capture the flag, king defend and control, basket bomber ball, endurance time trial)
+//   131071 $mutsbitgsp3 (protect capture the flag, attack bomber ball, gauntlet time trial)
+//   262143 $mutsbitall (all of the bits added together)
 //
 // sv_modelockfilter 60 // determines the game modes which are allowed to be used
 // sv_rotatemodefilter 60 // determines the game modes which are allowed to be chosen when there are no votes and the server picks a random game


### PR DESCRIPTION
The documented values for $mutsbitresize and $mutsbithard had to be swapped, the value for $mutsbitbasic was missing, the values for $mutsbitgsp* and $mutsbitall had to be incremented accordingly.