### PR TITLE
Fix compilation under C++11

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -25,7 +25,7 @@ extern char *systemuser, *systemhost;
 
 #define sup_platform(a) (a >= 0 && a < MAX_PLATFORMS)
 #define sup_arch(a) (a == 32 || a == 64)
-#define sup_var(a) VERSION_VNAME"_"a
+#define sup_var(a) VERSION_VNAME"_" a
 
 extern const char *platnames[MAX_PLATFORMS], *platlongnames[MAX_PLATFORMS];
 #define plat_name(a) (sup_platform(a) ? platnames[a] : "unk")


### PR DESCRIPTION
This fixes compilation under the latest GCC, which uses C++11 by default.

In C++11, the `a` at the end of the changed line is interpreted as a string literal operator unless there is a space before it.

This pull request fixes #506.