### PR TITLE
Send randweap filter with N_CONNECT

### DIFF
--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1656,6 +1656,8 @@ namespace client
         sendstring(game::player1->vanity, p);
         putint(p, game::player1->loadweap.length());
         loopv(game::player1->loadweap) putint(p, game::player1->loadweap[i]);
+        putint(p, game::player1->randweap.length());
+        loopv(game::player1->randweap) putint(p, game::player1->randweap[i]);
 
         string hash = "";
         if(connectpass[0])

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -5726,6 +5726,13 @@ namespace server
                             if(k >= W_LOADOUT) getint(p);
                             else ci->loadweap.add(getint(p));
                         }
+                        int rw = getint(p);
+                        ci->randweap.shrink(0);
+                        loopk(rw)
+                        {
+                            if(k >= W_LOADOUT) getint(p);
+                            else ci->randweap.add(getint(p));
+                        }
 
                         string password = "", authname = "";
                         getstring(password, p);


### PR DESCRIPTION
Currently the random weapon filter is only send with N_SETPLAYERINFO, resulting in a possibility of selecting filtered weapons at the start of a game.

This breaks protocol.