### PR TITLE
Fix zoom jerking. Closes #518. Remove unused inzoomswitch().

### DIFF
--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1674,7 +1674,7 @@ namespace hud
 enum { CTONE_TEAM = 0, CTONE_TONE, CTONE_TEAMED, CTONE_ALONE, CTONE_MIXED, CTONE_TMIX, CTONE_AMIX, CTONE_MAX };
 namespace game
 {
-    extern int gamestate, gamemode, mutators, nextmode, nextmuts, timeremaining, lasttimeremain, maptime, lastzoom, lasttvcam, lasttvchg, spectvtime, waittvtime,
+    extern int gamestate, gamemode, mutators, nextmode, nextmuts, timeremaining, lasttimeremain, maptime, lastzoom, prevzoom, lasttvcam, lasttvchg, spectvtime, waittvtime,
             bloodfade, bloodsize, bloodsparks, debrisfade, eventiconfade, eventiconshort,
             announcefilter, dynlighteffects, aboveheadnames, followthirdperson, nogore, forceplayermodel,
             playerovertone, playerundertone, playerdisplaytone, playereffecttone, playerteamtone, follow, specmode, spectvfollow, spectvfollowing, clientcrc;
@@ -1724,7 +1724,6 @@ namespace game
     extern int deadzone();
     extern void checkzoom();
     extern bool inzoom();
-    extern bool inzoomswitch();
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
     extern void resetcamera(bool cam = true, bool input = true);

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1314,7 +1314,12 @@ namespace hud
             {
                 int frame = lastmillis-game::lastzoom, off = int(zoomcrosshairsize*hudsize)-cs;
                 float amt = frame <= W(game::focus->weapselect, cookzoom) ? clamp(float(frame)/float(W(game::focus->weapselect, cookzoom)), 0.f, 1.f) : 1.f;
-                if(!game::zooming) amt = 1.f-amt;
+                if(!game::zooming)
+                {
+                    float prevframe = game::lastzoom - game::prevzoom;
+                    float maxamt = prevframe <= W(game::focus->weapselect, cookzoom) ? float(prevframe)/float(W(game::focus->weapselect, cookzoom)) : 1.f;
+                    amt = amt > maxamt ? 0.f : maxamt - amt;
+                }
                 cs += int(off*amt);
                 fade += (zoomcrosshairblend-fade)*amt;
             }
@@ -3262,7 +3267,12 @@ namespace hud
         Texture *t = textureload(zoomtex, 3);
         int frame = lastmillis-game::lastzoom;
         float pc = frame <= W(game::focus->weapselect, cookzoom) ? float(frame)/float(W(game::focus->weapselect, cookzoom)) : 1.f;
-        if(!game::zooming) pc = 1.f-pc;
+        if(!game::zooming)
+        {
+            float prevframe = game::lastzoom - game::prevzoom;
+            float maxpc = prevframe <= W(game::focus->weapselect, cookzoom) ? float(prevframe)/float(W(game::focus->weapselect, cookzoom)) : 1.f;
+            pc = pc > maxpc ? 0.f : maxpc - pc;
+        }
         int x = 0, y = 0, c = 0;
         if(w > h)
         {


### PR DESCRIPTION
`bool prevzoom` was unused too, so I thought it's a good name for the new usecase. There's a lot of repetition there probably could be something like `progress` function/macro.