### PR TITLE
Fix zoom jerking. Closes #518. Remove unused inzoomswitch(), prevzoom.

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4,7 +4,7 @@ namespace game
 {
     int nextmode = G_EDITMODE, nextmuts = 0, gamestate = G_S_WAITING, gamemode = G_EDITMODE, mutators = 0, maptime = 0, timeremaining = 0, lasttimeremain = 0,
         lastcamera = 0, lasttvcam = 0, lasttvchg = 0, lastzoom = 0, spectvfollowing = -1, starttvcamdyn = -1, lastcamcn = -1;
-    bool prevzoom = false, zooming = false, inputmouse = false, inputview = false, inputmode = false;
+    bool zooming = false, inputmouse = false, inputview = false, inputmode = false;
     float swayfade = 0, swayspeed = 0, swaydist = 0, bobfade = 0, bobdist = 0;
     vec swaydir(0, 0, 0), swaypush(0, 0, 0);
 
@@ -514,8 +514,7 @@ namespace game
     {
         if(on != zooming)
         {
-            lastzoom = millis;
-            prevzoom = zooming;
+            lastzoom = millis - max(W(focus->weapselect, cookzoom) - (millis - lastzoom), 0);
             if(zoomdefault >= 0 && on) zoomlevel = zoomdefault;
         }
         checkzoom();
@@ -529,13 +528,6 @@ namespace game
         return false;
     }
     ICOMMAND(0, iszooming, "", (), intret(inzoom() ? 1 : 0));
-
-    bool inzoomswitch()
-    {
-        if(lastzoom && ((zooming && lastmillis-lastzoom >= W(focus->weapselect, cookzoom)/2) || (!zooming && lastmillis-lastzoom <= W(focus->weapselect, cookzoom)/2)))
-            return true;
-        return false;
-    }
 
     void resetsway()
     {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -1724,7 +1724,6 @@ namespace game
     extern int deadzone();
     extern void checkzoom();
     extern bool inzoom();
-    extern bool inzoomswitch();
     extern void zoomview(bool down);
     extern bool tvmode(bool check = true, bool force = true);
     extern void resetcamera(bool cam = true, bool input = true);


### PR DESCRIPTION
https://github.com/red-eclipse/base/pull/540