### PR TITLE
Make sure N_EDITENT is sent before N_ITEMSPAWN. Fix #535.

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -6993,7 +6993,12 @@ namespace server
                     {
                         if(oldtype == PLAYERSTART || sents[n].type == PLAYERSTART) setupspawns(true);
                         hasgameinfo = true;
-                        QUEUE_MSG;
+                        packetbuf cep(MAXTRANS, ENET_PACKET_FLAG_RELIABLE);
+                        putint(cep, N_CLIENT);
+                        putint(cep, ci->clientnum);
+                        putuint(cep, p.length());
+                        cep.put(p.getbuf(), p.length());
+                        sendpacket(-1, 1, cep.finalize(), ci->clientnum);
                         if(tweaked && enttype[sents[n].type].usetype != EU_NONE)
                         {
                             if(enttype[sents[n].type].usetype == EU_ITEM) setspawn(n, true, true, true);


### PR DESCRIPTION
`setspawn` sends `N_ITEMSPAWN` instantly, but `N_EDITENT` message to create a weapon is queued and sent later, thus other players in multplayer editing get `N_ITEMSPAWN` for nonexisting item. I'm not sure what would be the best way to fix it. I havent found any proper function to queue messages and I'm not even sure if it's possible to queue 2 messages. So I decided to send `N_EDITENT` instantly instead of deferring `N_ITEMSPAWN`. And again I havent found any function to prepend `N_CLIENT` information to the package so I just wrote it inline.