### PR TITLE
two small mem leaks fixes :

### DIFF
--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -1245,7 +1245,7 @@ done:
     }
     return;
 invalid:
-    if (lookup) delete[] lookup;
+    delete[] lookup;
     switch(ltype)
     {
         case VAL_NULL: case VAL_ANY: compilenull(code); break;

--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -1245,6 +1245,7 @@ done:
     }
     return;
 invalid:
+    if (lookup) delete[] lookup;
     switch(ltype)
     {
         case VAL_NULL: case VAL_ANY: compilenull(code); break;

--- a/src/engine/irc.cpp
+++ b/src/engine/irc.cpp
@@ -50,7 +50,7 @@ void ircprintf(ircnet *n, int relay, const char *target, const char *msg, ...)
     {
         formatstring(s, "\fs\fa[%s]\fS", n->name);
         #ifndef STANDALONE
-        n->buffer.addline(newstring(str), MAXIRCLINES);
+        n->buffer.addline(str, MAXIRCLINES);
         n->updated |= IRCUP_MSG;
         #endif
     }


### PR DESCRIPTION
lookup might have been allocated in the invalid block.
addline already allocate memory.

PS : sorry for the previous PR, was not really intended.