### PR TITLE
Force filtered-out random weapons to be selected if needed to fill maxcarry.

### DIFF
--- a/src/game/game.h
+++ b/src/game/game.h
@@ -838,10 +838,8 @@ struct clientstate
         }
         if(AA(actortype, maxcarry) && m_loadout(gamemode, mutators))
         {
-            int n = 0;
-            int unfiltered = 0;
-            loopj(W_LOADOUT) if(canrandweap(j + W_OFFSET)) unfiltered++;
-            int musthave = AA(actortype, maxcarry) - unfiltered;
+            int n = 0, musthave = AA(actortype, maxcarry);
+            loopj(W_LOADOUT) if(canrandweap(j + W_OFFSET)) musthave--;
             vector<bool> forced;
             loopj(W_LOADOUT) forced.add(false);
             vector<int> aweap;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -839,6 +839,11 @@ struct clientstate
         if(AA(actortype, maxcarry) && m_loadout(gamemode, mutators))
         {
             int n = 0;
+            int unfiltered = 0;
+            loopj(W_LOADOUT) if(canrandweap(j + W_OFFSET)) unfiltered++;
+            int musthave = AA(actortype, maxcarry) - unfiltered;
+            vector<bool> forced;
+            loopj(W_LOADOUT) forced.add(false);
             vector<int> aweap;
             loopj(W_LOADOUT) aweap.add(loadweap.inrange(j) ? loadweap[j] : 0);
             loopvj(aweap)
@@ -847,7 +852,14 @@ struct clientstate
                 {
                     for(int t = rnd(W_ITEM-W_OFFSET)+W_OFFSET, r = 0; r < W_LOADOUT; r++)
                     {
-                        if(t >= W_OFFSET && t < W_ITEM && !hasweap(t, sweap) && m_check(W(t, modes), W(t, muts), gamemode, mutators) && !W(t, disabled) && canrandweap(t))
+                        bool canuse = canrandweap(t);
+                        if(!canuse && musthave > 0 && !forced[t - W_OFFSET])
+                        {
+                            canuse = true;
+                            musthave--;
+                            forced[t - W_OFFSET] = true;
+                        }
+                        if(t >= W_OFFSET && t < W_ITEM && !hasweap(t, sweap) && m_check(W(t, modes), W(t, muts), gamemode, mutators) && !W(t, disabled) && canuse)
                         {
                             aweap[j] = t;
                             break;


### PR DESCRIPTION
Currently the random weapon filter can cause less than `maxcarry` slots to be filled. This does not seem proper behaviour to me, this PR changes it so that `maxcarry` slots are always filled, and the random weapon filter takes a lower priority than filling all the slots.