### PR TITLE
Add combined kdratio for better team balancing.

### DIFF
--- a/src/game/game.h
+++ b/src/game/game.h
@@ -804,6 +804,11 @@ struct clientstate
         return frags >= deaths ? (frags/float(max(deaths, 1))) : -(deaths/float(max(frags, 1)));
     }
 
+    float combinedkdratio()
+    {
+        return kdratio() + kdratio(false);
+    }
+
     bool canrandweap(int weap)
     {
         int cweap = weap-W_OFFSET;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -1633,11 +1633,13 @@ namespace server
                                 case 3: if(id < 0 || tc[i][id]->totalfrags > cp->totalfrags) id = j; break;
                                 case 4: if(id < 0 || tc[i][id]->scoretime(false) > cp->scoretime(false)) id = j; break;
                                 case 5: if(id < 0 || tc[i][id]->kdratio() > cp->kdratio()) id = j; break;
-                                case 6: if(id < 0 || tc[i][id]->timeplayed < cp->timeplayed) id = j; break;
-                                case 7: if(id < 0 || tc[i][id]->totalpoints < cp->totalpoints) id = j; break;
-                                case 8: if(id < 0 || tc[i][id]->totalfrags < cp->totalfrags) id = j; break;
-                                case 9: if(id < 0 || tc[i][id]->scoretime(false) < cp->scoretime(false)) id = j; break;
-                                case 10: if(id < 0 || tc[i][id]->kdratio() < cp->kdratio()) id = j; break;
+                                case 6: if(id < 0 || tc[i][id]->combinedkdratio() > cp->combinedkdratio()) id = j; break;
+                                case 7: if(id < 0 || tc[i][id]->timeplayed < cp->timeplayed) id = j; break;
+                                case 8: if(id < 0 || tc[i][id]->totalpoints < cp->totalpoints) id = j; break;
+                                case 9: if(id < 0 || tc[i][id]->totalfrags < cp->totalfrags) id = j; break;
+                                case 10: if(id < 0 || tc[i][id]->scoretime(false) < cp->scoretime(false)) id = j; break;
+                                case 11: if(id < 0 || tc[i][id]->kdratio() < cp->kdratio()) id = j; break;
+                                case 12: if(id < 0 || tc[i][id]->combinedkdratio() < cp->combinedkdratio()) id = j; break;
                                 case 0: default: if(id < 0) id = j; break;
                             }
                         }
@@ -2868,11 +2870,12 @@ namespace server
             float csk = 0, wsk = 0;
             switch(G(teambalancestyle))
             {
-                case 1: case 6: csk = ci->timeplayed; break;
-                case 2: case 7: csk = ci->totalpoints; break;
-                case 3: case 8: csk = ci->totalfrags; break;
-                case 4: case 9: csk = ci->scoretime(); break;
-                case 5: case 10: csk = ci->kdratio(); break;
+                case 1: case 7: csk = ci->timeplayed; break;
+                case 2: case 8: csk = ci->totalpoints; break;
+                case 3: case 9: csk = ci->totalfrags; break;
+                case 4: case 10: csk = ci->scoretime(); break;
+                case 5: case 11: csk = ci->kdratio(); break;
+                case 6: case 12: csk = ci->combinedkdratio(); break;
                 case 0: default: break;
             }
             loopv(clients) if(clients[i] && clients[i] != ci)
@@ -2882,11 +2885,12 @@ namespace server
                 float psk = 0;
                 switch(G(teambalancestyle))
                 {
-                    case 1: case 6: psk = cp->timeplayed; break;
-                    case 2: case 7: psk = cp->totalpoints; break;
-                    case 3: case 8: psk = cp->totalfrags; break;
-                    case 4: case 9: psk = cp->scoretime(); break;
-                    case 5: case 10: psk = cp->kdratio(); break;
+                    case 1: case 7: psk = cp->timeplayed; break;
+                    case 2: case 8: psk = cp->totalpoints; break;
+                    case 3: case 9: psk = cp->totalfrags; break;
+                    case 4: case 10: psk = cp->scoretime(); break;
+                    case 5: case 11: psk = cp->kdratio(); break;
+                    case 6: case 12: psk = ci->combinedkdratio(); break;
                     case 0: default: break;
                 }
                 if(psk > csk || psk > wsk) continue;
@@ -2994,11 +2998,12 @@ namespace server
                 { // remember: ai just balance teams
                     switch(G(teambalancestyle))
                     {
-                        case 1: case 6: ts.score += cp->timeplayed; break;
-                        case 2: case 7: ts.score += cp->totalpoints; break;
-                        case 3: case 8: ts.score += cp->totalfrags; break;
-                        case 4: case 9: ts.score += cp->scoretime(); break;
-                        case 5: case 10: ts.score += cp->kdratio(); break;
+                        case 1: case 7: ts.score += cp->timeplayed; break;
+                        case 2: case 8: ts.score += cp->totalpoints; break;
+                        case 3: case 9: ts.score += cp->totalfrags; break;
+                        case 4: case 10: ts.score += cp->scoretime(); break;
+                        case 5: case 11: ts.score += cp->kdratio(); break;
+                        case 6: case 12: ts.score += cp->combinedkdratio(); break;
                         case 0: default: ts.score += 1; break;
                     }
                     ts.clients++;

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -293,7 +293,7 @@ GVAR(IDF_GAMEMOD, teambalancewait, 0, 10000, VAR_MAX); // how long before can ha
 GVAR(IDF_GAMEMOD, teambalancedelay, 0, 3000, VAR_MAX); // how long before reassignments start
 GVAR(IDF_GAMEMOD, teambalanceswap, 0, 1, 1); // allow swap requests if unable to change team
 GVAR(IDF_GAMEMOD, teambalancelock, 0, PRIV_MODERATOR, PRIV_MAX); // level at which one can override swap
-GVAR(IDF_GAMEMOD, teambalancestyle, 0, 10, 10); // when moving players, sort by: 0 = top of list, 1 = lowest time played, 2 = lowest points, 3 = lowest frags, 4 = lowest scoretime, 5 = lowest kdratio, 6 = highest time played, 7 = highest points, 8 = highest frags, 9 = highest scoretime, 10 = highest kdratio
+GVAR(IDF_GAMEMOD, teambalancestyle, 0, 12, 12); // when moving players, sort by: 0 = top of list, 1 = lowest time played, 2 = lowest points, 3 = lowest frags, 4 = lowest scoretime, 5 = lowest kdratio, 6 = lowest combined kdratio, 7 = highest time played, 8 = highest points, 9 = highest frags, 10 = highest scoretime, 11 = highest kdratio, 12 = highest combined kdratio
 
 GVAR(IDF_GAMEMOD, racegauntletwinner, 0, 1, 1); // declare the winner when the final team exceeds best score
 


### PR DESCRIPTION
Currently the default balance style is by kills/deaths from global statistics. This does not take into account current performance, which means that players who are not up to their usual skill, or skilled players who do not have many games in statistics cannot be counted correctly.

This pull request adds a "combined kdratio" option that adds the k/d ratio from the global statistics with the ratio from the current game, allowing for balancing to fit the current game more closely.