### PR TITLE
ctf fixes

### DIFF
--- a/src/game/capture.cpp
+++ b/src/game/capture.cpp
@@ -495,14 +495,19 @@ namespace capture
         capturestate::flag &f = st.flags[i];
         if(value > 0)
         {
-            affinityeffect(i, T_NEUTRAL, f.droploc, f.above, 3, "RESET");
+            affinityeffect(i, T_NEUTRAL, f.droploc, value == 2 ? pos : f.above, 3, "RESET");
             game::spawneffect(PART_SPARK, vec(f.pos()).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, TEAM(f.team, colour), 1.5f);
             game::spawneffect(PART_SPARK, vec(f.pos()).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, 0xFFFFFF, 1.5f);
             game::spawneffect(PART_SPARK, value == 2 ? pos : vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, TEAM(f.team, colour), 1.5f);
             game::spawneffect(PART_SPARK, value == 2 ? pos : vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, 0xFFFFFF, 1.5f);
             game::announcef(S_V_FLAGRESET, CON_SELF, NULL, true, "\fathe %s flag has been reset", game::colourteam(f.team, "flagtex"));
         }
-        if(value == 2) st.dropaffinity(i, pos, vec(0, 0, 1), lastmillis);
+        if(value == 2)
+        {
+            st.dropaffinity(i, pos, vec(0, 0, 1), lastmillis);
+            f.proj->stuck = 1;
+            f.proj->stick = NULL;
+        }
         else st.returnaffinity(i, lastmillis);
     }
 

--- a/src/game/capture.cpp
+++ b/src/game/capture.cpp
@@ -517,7 +517,7 @@ namespace capture
         float radius = enttype[AFFINITY].radius;
         vec abovegoal, capturepos, returnpos;
         capturestate::flag &f = st.flags[relay];
-        if (st.flags.inrange(goal))
+        if(st.flags.inrange(goal))
         {
             capturestate::flag &g = st.flags[goal];
             abovegoal = g.above;

--- a/src/game/capture.cpp
+++ b/src/game/capture.cpp
@@ -508,14 +508,25 @@ namespace capture
 
     void scoreaffinity(gameent *d, int relay, int goal, int score)
     {
-        if(!st.flags.inrange(relay) || !st.flags.inrange(goal)) return;
+        if(!st.flags.inrange(relay)) return;
+        float radius = enttype[AFFINITY].radius;
+        vec abovegoal, capturepos, returnpos;
         capturestate::flag &f = st.flags[relay];
-        capturestate::flag &g = st.flags[goal];
-        affinityeffect(goal, d->team, g.above, f.above, 3, "CAPTURED");
-        game::spawneffect(PART_SPARK, vec(g.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, TEAM(g.team, colour), 1.5f);
-        game::spawneffect(PART_SPARK, vec(g.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, 0xFFFFFF, 1.5f);
-        game::spawneffect(PART_SPARK, vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, TEAM(f.team, colour), 1.5f);
-        game::spawneffect(PART_SPARK, vec(f.spawnloc).add(vec(0, 0, enttype[AFFINITY].radius*0.45f)), enttype[AFFINITY].radius*0.25f, 0xFFFFFF, 1.5f);
+        if (st.flags.inrange(goal))
+        {
+            capturestate::flag &g = st.flags[goal];
+            abovegoal = g.above;
+            capturepos = g.spawnloc;
+        }
+        else abovegoal = capturepos = f.pos(true); // m_ctf_protect
+        returnpos = vec(f.spawnloc);
+        returnpos.add(vec(0, 0, radius*0.45f));
+        capturepos.add(vec(0, 0, radius*0.45f));
+        affinityeffect(goal, d->team, abovegoal, f.above, 3, "CAPTURED");
+        game::spawneffect(PART_SPARK, capturepos, radius*0.25f, TEAM(d->team, colour), 1.5f);
+        game::spawneffect(PART_SPARK, capturepos, radius*0.25f, 0xFFFFFF, 1.5f);
+        game::spawneffect(PART_SPARK, returnpos, radius*0.25f, TEAM(f.team, colour), 1.5f);
+        game::spawneffect(PART_SPARK, returnpos, radius*0.25f, 0xFFFFFF, 1.5f);
         hud::teamscore(d->team).total = score;
         defformatstring(fteam, "%s", game::colourteam(f.team, "flagtex"));
         game::announcef(S_V_FLAGSCORE, CON_SELF, d, true, "\fa%s captured the %s flag for team %s (score: \fs\fc%d\fS, time taken: \fs\fc%s\fS)", game::colourname(d), fteam, game::colourteam(d->team), score, timestr(lastmillis-f.taketime, 1));

--- a/src/game/capture.h
+++ b/src/game/capture.h
@@ -194,15 +194,6 @@ struct capturestate
         destroy(i);
 #endif
     }
-    
-    bool cantake(int i, int cn, int t)
-    {
-#ifdef GAMESERVER
-        flag &f = flags[i];
-        if (f.lastowner == cn && f.returntime + 1000 >= t) return false;
-#endif
-        return true;
-    }
 };
 
 #ifndef GAMESERVER

--- a/src/game/capture.h
+++ b/src/game/capture.h
@@ -13,7 +13,7 @@ struct capturestate
         vec droploc, inertia, spawnloc;
         int team, yaw, pitch, droptime, taketime, dropoffset;
 #ifdef GAMESERVER
-        int owner, lastowner;
+        int owner, lastowner, returntime;
         vector<int> votes;
         vec floorpos;
 #else
@@ -32,6 +32,7 @@ struct capturestate
             droploc = spawnloc = vec(-1, -1, -1);
 #ifdef GAMESERVER
             owner = lastowner = -1;
+            returntime = 0;
             votes.shrink(0);
             floorpos = vec(-1, -1, -1);
 #else
@@ -183,6 +184,7 @@ struct capturestate
 #endif
         f.droptime = f.taketime = f.dropoffset = 0;
 #ifdef GAMESERVER
+        f.returntime = t;
         f.owner = -1;
         f.votes.shrink(0);
         f.floorpos = vec(-1, -1, -1);
@@ -191,6 +193,15 @@ struct capturestate
         f.owner = NULL;
         destroy(i);
 #endif
+    }
+    
+    bool cantake(int i, int cn, int t)
+    {
+#ifdef GAMESERVER
+        flag &f = flags[i];
+        if (f.lastowner == cn && f.returntime + 1000 >= t) return false;
+#endif
+        return true;
     }
 };
 

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -100,7 +100,7 @@ struct captureservmode : capturestate, servmode
         flag &f = flags[i];
         if(f.owner >= 0 || (f.team == ci->team && (m_ctf_defend(gamemode, mutators) || (m_ctf_quick(gamemode, mutators) && !f.droptime)))) return;
         if(f.lastowner == ci->clientnum && f.droptime && gamemillis-f.droptime <= G(capturepickupdelay)) return;
-        if(!m_ctf_protect(gamemode, mutators) && f.team != ci->team && !capturestate::cantake(i, ci->clientnum, gamemillis)) return;
+        if(!m_ctf_protect(gamemode, mutators) && f.team != ci->team && f.lastowner == ci->clientnum && f.returntime + G(captureretakedelay) >= gamemillis) return;
         if(m_ctf_quick(gamemode, mutators) && f.team == ci->team)
         {
             capturestate::returnaffinity(i, gamemillis);

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -100,6 +100,7 @@ struct captureservmode : capturestate, servmode
         flag &f = flags[i];
         if(f.owner >= 0 || (f.team == ci->team && (m_ctf_defend(gamemode, mutators) || (m_ctf_quick(gamemode, mutators) && !f.droptime)))) return;
         if(f.lastowner == ci->clientnum && f.droptime && gamemillis-f.droptime <= G(capturepickupdelay)) return;
+        if(!m_ctf_protect(gamemode, mutators) && f.team != ci->team && !capturestate::cantake(i, ci->clientnum, gamemillis)) return;
         if(m_ctf_quick(gamemode, mutators) && f.team == ci->team)
         {
             capturestate::returnaffinity(i, gamemillis);

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -65,7 +65,7 @@ struct captureservmode : capturestate, servmode
         if(!canplay() || !hasflaginfo || !(AA(ci->actortype, abilities)&(1<<A_A_AFFINITY)) || ci->state != CS_ALIVE) return;
         if(ci->floorpos != vec(-1, -1, -1))
             loopv(flags) if(flags[i].owner == ci->clientnum)
-                (flags[i].floorpos = ci->floorpos).z += (enttype[AFFINITY].radius/2)+1;
+                (flags[i].floorpos = ci->floorpos).z += (enttype[AFFINITY].radius/4)+1;
         if(G(capturethreshold) > 0 && oldpos.dist(newpos) >= G(capturethreshold))
             dropaffinity(ci, oldpos, vec(ci->vel).add(ci->falling));
         if(!m_ctf_protect(gamemode, mutators)) loopv(flags) if(flags[i].owner == ci->clientnum)
@@ -112,7 +112,7 @@ struct captureservmode : capturestate, servmode
             capturestate::takeaffinity(i, ci->clientnum, gamemillis);
             if(ci->floorpos != vec(-1, -1, -1)) f.floorpos = ci->floorpos;
             else f.floorpos = f.droploc;
-            f.floorpos.z += (enttype[AFFINITY].radius/2)+1;
+            f.floorpos.z += (enttype[AFFINITY].radius/4)+1;
             if((f.team != ci->team && !f.droptime) || f.lastowner != ci->clientnum) givepoints(ci, G(capturepickuppoints), m_points(gamemode, mutators), false);
             sendf(-1, 1, "ri3", N_TAKEAFFIN, ci->clientnum, i);
         }
@@ -126,12 +126,15 @@ struct captureservmode : capturestate, servmode
         f.votes.add(ci->clientnum);
         if(f.votes.length() >= int(floorf(numclients()*0.5f)))
         {
-            if(G(captureresetfloor) && f.floorpos != vec(-1, -1, -1))
+            if(G(captureresetfloor))
             {
-                ivec pos = ivec(vec(f.floorpos).mul(DMF));
-                capturestate::dropaffinity(i, f.floorpos, vec(0, 0, 1), gamemillis);
-                f.floorpos = vec(-1, -1, -1); // in case its a fail
-                sendf(-1, 1, "ri3i3", N_RESETAFFIN, i, 2, pos.x, pos.y, pos.z);
+                if (f.floorpos != vec(-1, -1, -1))
+                {
+                    ivec pos = ivec(vec(f.floorpos).mul(DMF));
+                    capturestate::dropaffinity(i, f.floorpos, vec(0, 0, 1), gamemillis);
+                    f.floorpos = vec(-1, -1, -1);
+                    sendf(-1, 1, "ri3i3", N_RESETAFFIN, i, 2, pos.x, pos.y, pos.z);
+                }
             }
             else
             {

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -128,7 +128,7 @@ struct captureservmode : capturestate, servmode
         {
             if(G(captureresetfloor))
             {
-                if (f.floorpos != vec(-1, -1, -1))
+                if(f.floorpos != vec(-1, -1, -1))
                 {
                     ivec pos = ivec(vec(f.floorpos).mul(DMF));
                     capturestate::dropaffinity(i, f.floorpos, vec(0, 0, 1), gamemillis);

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -678,6 +678,7 @@ namespace projs
     bool spherecheck(projent &proj, bool rev = false)
     {
         if(!insideworld(proj.o)) return false;
+        if (proj.stuck) return false;
         vec dir = vec(proj.vel).normalize();
         if(collide(&proj, dir, 1e-6f, false) || collideinside)
         {

--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -678,7 +678,7 @@ namespace projs
     bool spherecheck(projent &proj, bool rev = false)
     {
         if(!insideworld(proj.o)) return false;
-        if (proj.stuck) return false;
+        if(proj.stuck) return false;
         vec dir = vec(proj.vel).normalize();
         if(collide(&proj, dir, 1e-6f, false) || collideinside)
         {

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -328,6 +328,7 @@ GFVAR(IDF_GAMEMOD, capturebuffshield, 1, 1.25f, FVAR_MAX); // divide incoming da
 GVAR(IDF_GAMEMOD, captureregenbuff, 0, 1, 1); // 0 = off, 1 = modify regeneration when buffed
 GVAR(IDF_GAMEMOD, captureregendelay, 0, 1000, VAR_MAX); // regen this often when buffed
 GVAR(IDF_GAMEMOD, captureregenextra, 0, 2, VAR_MAX); // add this to regen when buffed
+GVAR(IDF_GAMEMOD, captureretakedelay, 0, 1000, VAR_MAX); // same person can't take same flag this long after capturing it
 
 GVAR(IDF_GAMEMOD, defendlimit, 0, 0, VAR_MAX); // finish when score is this or more
 GVAR(IDF_GAMEMOD, defendpoints, 0, 1, VAR_MAX); // points added to score


### PR DESCRIPTION
Please see http://redeclipse.net/forum/viewtopic.php?f=4&t=1010 for context.

### Protect ctf
Commit 9f3d1f3c forgot to account for protect ctf, which has no goal flag.

### Multiple capture glitch
When a player is near a loose flag, the client keeps sending a N_TAKEAFFIN messages every frame. When the server sees the first one, it assigns the flag to the player. If said player is also at her home base, the server gives her a point and returns the flag to its base. Then, the next queued up N_TAKEAFFIN arrives, and the server thinks the player picked up the flag again, and immediately scores again...
This patch will make the server reject N_TAKEAFFIN from the same player for one second after a capture (for the same flag only).

### Flag reset change
There are two issues here.

One is that with at least two players, a flag dropped into deathmat resets back to base instead of where it was dropped from, as intended. That's because loose flags are reset when half of the connected clients (rounded down) send an N_RESETAFFIN message. The first reset puts the flag to where it was dropped from (`floorpos`). But then, immediately, the other half of the votes roll in, and the flag is sent to its base. Raising the required number of votes did not solve this issue, because for some reason the clients occasionally double vote for each flag, usually when multiple are dropped at the same time.

An unrelated problem (e.g. happens even in offline single player) is that if a player walk off a cliff and drops a flag in the abyss, it returns to the edge of the cliff. And if that edge happens to be sloped down towards the chasm, then the flag bounces right back down into the deep. Surely, some players would learn the spots where this is reliably doable (f.e. on *Darkness* next to the pusher), and abuse it.

To solve these, this patch makes flags freeze at the gound position where they are reset to. Since `floorpos` is always at ground level and reachable by players, there's no need to apply bouncy physics. Also, since they cannot move, they cannot get in deathmat, so further N_RESETAFFIN can be ignored.

The freezing is achieved by setting the `stuck` member to 1. Also, `spherecheck` had to be disabled for stuck flags, because it was moving them off of cliffs. I hope this doesn't break stuff.
