### PR TITLE
Make bots use weapons except pistol/botweaponspawn

### DIFF
--- a/src/game/ai.cpp
+++ b/src/game/ai.cpp
@@ -146,7 +146,7 @@ namespace ai
 
     int weappref(gameent *d)
     {
-        if(!m_basic(game::gamemode, game::mutators) && d->loadweap.length()) return d->loadweap[0];
+        if(d->loadweap.length()) return d->loadweap[0];
         return m_weapon(d->actortype, game::gamemode, game::mutators);
     }
 


### PR DESCRIPTION
I'm not sure if it's the right fix for that. That check makes bots spawn with `botweaponspawn` in basic, which is pistol by default, and they just don't want to switch from that (the result is that all bots use pistol). If `botweaponspawn` is set to some other value bots might choose to switch it, however for some weapons like smg and zapper they prefer to keep it. That is why I'm not sure whether something should be changed in how AI switches weapons, or that check should be removed. Or maybe it was meant as `!m_classic`, `!m_basic` doesn't quite make sense to me :)
