### PR TITLE
Extend captureresetfloor.

### DIFF
--- a/src/game/capture.h
+++ b/src/game/capture.h
@@ -13,7 +13,7 @@ struct capturestate
         vec droploc, inertia, spawnloc;
         int team, yaw, pitch, droptime, taketime, dropoffset;
 #ifdef GAMESERVER
-        int owner, lastowner, returntime;
+        int owner, lastowner, lastownerteam, returntime;
         vector<int> votes;
         vec floorpos;
 #else
@@ -32,7 +32,7 @@ struct capturestate
             droploc = spawnloc = vec(-1, -1, -1);
 #ifdef GAMESERVER
             owner = lastowner = -1;
-            returntime = 0;
+            lastownerteam = returntime = 0;
             votes.shrink(0);
             floorpos = vec(-1, -1, -1);
 #else
@@ -126,7 +126,7 @@ struct capturestate
 #endif
 
 #ifdef GAMESERVER
-    void takeaffinity(int i, int owner, int t)
+    void takeaffinity(int i, int owner, int t, int ownerteam)
 #else
     void takeaffinity(int i, gameent *owner, int t)
 #endif
@@ -142,6 +142,7 @@ struct capturestate
 #ifdef GAMESERVER
         f.votes.shrink(0);
         f.lastowner = owner;
+        f.lastownerteam = ownerteam;
 #else
         f.movetime = 0;
         (f.lastowner = owner)->addicon(eventicon::AFFINITY, t, game::eventiconfade, f.team);

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -126,7 +126,7 @@ struct captureservmode : capturestate, servmode
         f.votes.add(ci->clientnum);
         if(f.votes.length() >= int(floorf(numclients()*0.5f)))
         {
-            if(G(captureresetfloor) && !(f.lastownerteam != f.team && G(captureresetfloor)>=2))
+            if(G(captureresetfloor) && (f.lastownerteam == f.team || G(captureresetfloor)<2))
             {
                 if(f.floorpos != vec(-1, -1, -1))
                 {

--- a/src/game/capturemode.h
+++ b/src/game/capturemode.h
@@ -109,7 +109,7 @@ struct captureservmode : capturestate, servmode
         }
         else
         {
-            capturestate::takeaffinity(i, ci->clientnum, gamemillis);
+            capturestate::takeaffinity(i, ci->clientnum, gamemillis, ci->team);
             if(ci->floorpos != vec(-1, -1, -1)) f.floorpos = ci->floorpos;
             else f.floorpos = f.droploc;
             f.floorpos.z += (enttype[AFFINITY].radius/4)+1;
@@ -126,7 +126,7 @@ struct captureservmode : capturestate, servmode
         f.votes.add(ci->clientnum);
         if(f.votes.length() >= int(floorf(numclients()*0.5f)))
         {
-            if(G(captureresetfloor))
+            if(G(captureresetfloor) && !(f.lastownerteam != f.team && G(captureresetfloor)>=2))
             {
                 if(f.floorpos != vec(-1, -1, -1))
                 {

--- a/src/game/vars.h
+++ b/src/game/vars.h
@@ -298,7 +298,7 @@ GVAR(IDF_GAMEMOD, teambalancestyle, 0, 12, 12); // when moving players, sort by:
 GVAR(IDF_GAMEMOD, racegauntletwinner, 0, 1, 1); // declare the winner when the final team exceeds best score
 
 GVAR(IDF_GAMEMOD, capturelimit, 0, 0, VAR_MAX); // finish when score is this or more
-GVAR(IDF_GAMEMOD, captureresetfloor, 0, 1, 1); // if tossed, reset to last floor pos
+GVAR(IDF_GAMEMOD, captureresetfloor, 0, 0, 2); // if tossed, reset to last floor pos
 GVAR(IDF_GAMEMOD, captureresetstore, 0, 2, 15);
 GVAR(IDF_GAMEMOD, captureresetdelay, 0, 30000, VAR_MAX);
 GVAR(IDF_GAMEMOD, capturedefenddelay, 0, 10000, VAR_MAX);


### PR DESCRIPTION
The new value, 2, makes the carrier's own flag reset to where it was
dropped from, while enemy flags reset to their base. Implements #593.

The default value for `captureresetfloor` is set to 0 for now
to be compatible with older clients. Fixes #595.