### PR TITLE
Coop editing

### DIFF
--- a/config/menus/editing.cfg
+++ b/config/menus/editing.cfg
@@ -423,15 +423,10 @@
                     guiloopscrollbar j $imax 15 15 [
                         p = (at $prefabs $j)
                         guibutton $p [
-                            pasteprefab @p 
-                            if $prefabcopy [
-                                editdel
-                                pasteprefab @@p
-                                copy
-                                undo
-                            ]
-                            cleargui 
-                        ] 
+                            copyprefab @p
+                            if $prefabcopy pastehilight paste
+                            cleargui
+                        ]
                     ]
                 ]
                 guinocursorfx [guiprefabpreview $guirollovername -1 [] 7.5 1 []]

--- a/config/setup.cfg
+++ b/config/setup.cfg
@@ -1,5 +1,5 @@
 complete exec .
-complete pasteprefab prefab obr
+complete copyprefab prefab obr
 
 mapcomplete     = [ setcomplete $arg1 1; complete $arg1 maps mpz ]; mapcomplete map
 start           = [ mode $arg2 $arg3; map $arg1 ]; mapcomplete start

--- a/src/engine/octaedit.cpp
+++ b/src/engine/octaedit.cpp
@@ -1280,13 +1280,29 @@ prefab *loadprefab(const char *name, bool msg = true)
    return b;
 }
 
-void pasteprefab(char *name)
+/* Create a copy of block3 */
+block3 *copyblock(block3 *s)
 {
-    if(!name[0] || noedit() || multiplayer()) return;
-    prefab *b = loadprefab(name, true);
-    if(b) pasteblock(*b->copy, sel, true);
+    int bsize = sizeof(block3)+sizeof(cube)*s->size();
+    if(bsize <= 0 || bsize > (100<<20)) return 0;
+    block3 *b = (block3 *)new uchar[bsize];
+    *b = *s;
+    loopi(s->size()) copycube(s->c()[i], b->c()[i]);
+    return b;
 }
-COMMAND(0, pasteprefab, "s");
+
+/* Copy prefab `name` to clipboard */
+void copyprefab(char *name)
+{
+    if(!name[0] || noedit()) return;
+    prefab *b = loadprefab(name, true);
+    if(!b) return;
+    if(multiplayer(false)) client::edittrigger(sel, EDIT_COPY, 1);
+    if(!localedit) localedit = editinfos.add(new editinfo);
+    if(localedit->copy) freeblock(localedit->copy);
+    localedit->copy = copyblock(b->copy);
+}
+COMMAND(0, copyprefab, "s");
 
 struct prefabmesh
 {

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1518,7 +1518,8 @@ namespace client
             outbuf = NULL;
             inlen = outlen = 0;
             needclipboard = -1;
-        } else needclipboard = 0;
+        }
+        else needclipboard = 0;
         packetbuf p(16 + outlen, ENET_PACKET_FLAG_RELIABLE);
         putint(p, N_CLIPBOARD);
         putint(p, inlen);

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1517,14 +1517,14 @@ namespace client
         {
             outbuf = NULL;
             inlen = outlen = 0;
-        }
+            needclipboard = -1;
+        } else needclipboard = 0;
         packetbuf p(16 + outlen, ENET_PACKET_FLAG_RELIABLE);
         putint(p, N_CLIPBOARD);
         putint(p, inlen);
         putint(p, outlen);
         if(outlen > 0) p.put(outbuf, outlen);
         sendclientpacket(p.finalize(), 1);
-        needclipboard = -1;
     }
 
     void edittrigger(const selinfo &sel, int op, int arg1, int arg2, int arg3, const VSlot *vs)

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1538,7 +1538,7 @@ namespace client
             {
                 switch(op)
                 {
-                    case EDIT_COPY: needclipboard = 0; break;
+                    case EDIT_COPY: needclipboard = arg1; break; // 0 - has clipboard; 1 - has clipboard with unknown geometry
                     case EDIT_PASTE:
                         if(needclipboard > 0)
                         {

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -7238,13 +7238,15 @@ namespace server
                         break;
                     }
                     if(p.remaining() < packlen) { disconnect_client(sender, DISC_MSGERR); return; }
-                    packetbuf q(32 + packlen, ENET_PACKET_FLAG_RELIABLE);
+                    uchar s[MAXTRANS];
+                    ucharbuf q(s, MAXTRANS);
                     putint(q, type);
                     putint(q, ci->clientnum);
                     putint(q, unpacklen);
                     putint(q, packlen);
                     if(packlen > 0) p.get(q.subbuf(packlen).buf, packlen);
-                    sendpacket(-1, 1, q.finalize(), ci->clientnum);
+                    ci->messages.put(q.buf, q.length());
+                    curmsg += q.length();
                     break;
                 }
 


### PR DESCRIPTION
This is a work towards #555.
- First commit fixes a bug similar to the one in #548, but regarding undo/redo. Because N_UNDO/N_REDO were sent out of order it was for example possible to introduce a situation where everyone except undoing client has a piece of geometry, since N_UNDO is sent for an action that hasn't been delivered to other clients yet. One example to reproduce it: /editbind N [ paste; undo ], then copy a piece of geometry (small enough for coop undo), press N, your client has no new geometry, other clients do have it.
- Second commit makes it possible for a player to join coop-editing game and paste a piece of geometry from a different map.
- Third commit replaces `pasteprefab` function with more granular `copyprefab`, that copies a prefab into player's clipboard. It is easy to implement `pasteprefab` in terms of `copyprefab`, but implementing `copyprefab` in terms of `pasteprefab` required double pasting prefab, deleting geometry, copying, undoing (that's when I found out about the bug fixed in 1st commit), which requires a lot of unnecessary network communications in coop editing, as well as makes it impossible to have big prefabs inserted on `V` in coop editing.

The protocol isn't changed at all, meaning clients using current version can receive and see pasted geometry/prefabs, but can't paste them themselves.
