### PR TITLE
Properly remove clients from the duel/survivor queue upon sudden death.

### DIFF
--- a/src/game/duelmut.h
+++ b/src/game/duelmut.h
@@ -257,7 +257,14 @@ struct duelservmode : servmode
                             restricted.add(cs);
                         }
                         else if(cs->points == restricted[0]->points) restricted.add(cs);
-                        else remqueue(cs, false);
+                    }
+                    loopv(clients)
+                    {
+                        clientinfo *cs = clients[i];
+                        if(duelqueue.find(cs) >= 0 && restricted.find(cs) < 0)
+                        {
+                            remqueue(cs, false);
+                        }
                     }
                 }
                 loopv(duelqueue)


### PR DESCRIPTION
It looks like the problem in #604 was when a client is added at `restricted[0]` they would never be removed from the queue, even when `restricted` was cleared and another client put in that place.

This PR moves the `remqueue` call from the else to a separate loop that runs over all clients once `restricted` has been fully filled and calls `remqueue` if the client is in the queue but not in `restricted`.

Fixes #604