### PR TITLE
server: don't fail to sendmap to one client when server has a map. cl…

### DIFF
--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1306,6 +1306,7 @@ namespace client
             default:
                 emptymap(0, true, name);
                 needsmap = totalmillis;
+                if(crc > 0) addmsg(N_GETMAP, "r");
                 break;
         }
         else sendcrcinfo = true;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3153,7 +3153,7 @@ namespace server
     bool getmap(clientinfo *ci, bool force)
     {
         if(gs_intermission(gamestate)) return false; // pointless
-        if(ci && !numclients(ci->clientnum))
+        if(ci && !numclients(ci->clientnum) && !hasmapdata())
         {
             ci->wantsmap = false;
             sendf(ci->clientnum, 1, "ri", N_FAILMAP);


### PR DESCRIPTION
…ient: request a map if server has it. Fix #582.

The change in `src/game/client.cpp` makes client to request a map if server already has it, instead of waiting for 30 seconds or waiting before player will try to spawn.
The change in `src/game/server.cpp` prevents server from rejecting getmap when there's one client who has no map, but server has the map.