### PR TITLE
Reset servers browser scroll on search

### DIFF
--- a/config/menus/servers.cfg
+++ b/config/menus/servers.cfg
@@ -315,7 +315,7 @@ servermenu = [
                 guitooltip "^faFilter by player names or handles, current map, mode or mutators, server description, IP address or port."
             ]
             guistrut 0.5
-            guifield searchstrval 18 [searchstr = $searchstrval; searchfilter = 1] -1 0 "" 0 "^fd <enter search terms>" 1
+            guifield searchstrval 18 [searchstr = $searchstrval; searchfilter = 1; sinfoindex = 0] -1 0 "" 0 "^fd <enter search terms>" 1
             guispring 1
             guicenterz [
                 guitext "sort:"


### PR DESCRIPTION
Currently when you scroll and then search in servers gui if it happens so that you scrolled below some of the matching servers they are now shown. It often looks like nothing was found and no scroll is shown indicating that you can scroll up to see more results.