### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ src/xcode/redeclipse.xcodeproj/project.pbxproj
 src/xcode/redeclipse.xcodeproj/project.xcworkspace
 src/xcode/redeclipse.xcodeproj/xcuserdata
 src/redeclipse.cscope_file_list
+src/build/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,120 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+# Use pkg-config to configure dependencies later
+find_package(PkgConfig REQUIRED)
+# the dependencies required by all platforms
+set(client_deps zlib sdl2 SDL2_image SDL2_mixer gl sqlite3)
+
+# the client depends on almost all the source files
+file(GLOB client_sources engine/*.cpp game/*.cpp shared/*.cpp support/sqlite3.c)
+
+# the server requires less source files
+file(GLOB server_sources
+    shared/crypto.cpp
+    shared/geom.cpp
+    shared/stream.cpp
+    shared/tools.cpp
+    shared/zip.cpp
+    support/sqlite3.c
+    engine/command.cpp
+    engine/irc.cpp
+    engine/master.cpp
+    engine/server.cpp
+    game/server.cpp
+)
+
+# genkey is a rather simple application
+file(GLOB genkey_sources
+    engine/genkey.cpp
+    shared/crypto.cpp
+)
+
+# neither server nor client need genkey.cpp
+# to avoid warnings about duplicate main()s, it has to be removed from their source lists
+file(GLOB genkey_cpp_path engine/genkey.cpp)
+list(REMOVE_ITEM client_sources ${genkey_cpp_path})
+list(REMOVE_ITEM server_sources ${genkey_cpp_path})
+
+# make sure sqlite3 is built with the correct flags
+file(GLOB sqlite3_cpp_path support/sqlite3.c)
+set_source_files_properties(support/sqlite3.c PROPERTIES
+    COMPILE_FLAGS "-DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION"
+)
+
+# platform specific code
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    list(APPEND client_deps x11)
+    link_libraries(rt)
+    set(BIN_SUFFIX "_linux")
+elseif(APPLE)
+    # build OS X specific Objective-C code
+    file(GLOB mac_client_sources
+        xcode/main.m xcode/macutils.mm
+        xcode/SDLmain.m xcode/ConsoleView.m
+    )
+    file(GLOB mac_server_sources
+        xcode/macutils.mm
+    )
+    list(APPEND client_sources ${mac_client_sources})
+    list(APPEND server_sources ${mac_server_sources})
+    set(BIN_SUFFIX "_osx")
+elseif(MINGW)
+    link_libraries(ws2_32 winmm)
+    set(BIN_SUFFIX "_windows")
+else()
+    set(BIN_SUFFIX "_native")
+endif()
+
+# configure dependencies with pkg-config
+foreach(dep IN LISTS client_deps)
+    pkg_check_modules(${dep} REQUIRED ${dep})
+
+    # add the necessary includes
+    foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
+        include_directories(${include_dir})
+    endforeach(include_dir)
+
+    # link to the libraries
+    foreach(lib IN LISTS ${dep}_LIBRARIES)
+        link_libraries(${lib})
+    endforeach(lib)
+
+    # tell the compiler where to find the libraries' binaries
+    foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
+        link_directories(${lib_dir})
+    endforeach(lib_dir)
+endforeach(dep)
+
+# configure enet
+add_subdirectory(enet)
+
+# configure local includes
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/engine
+    ${CMAKE_CURRENT_SOURCE_DIR}/game
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared
+    ${ENET_INCLUDE_DIRS}
+)
+
+# add the client executable and link it to enet
+add_executable(redeclipse_client${BIN_SUFFIX} ${client_sources})
+target_link_libraries(redeclipse_client${BIN_SUFFIX} enet)
+
+# add the server executable and link it to enet
+# (define STANDALONE to "notify" the preprocessor that the server is built this time)
+add_executable(redeclipse_server${BIN_SUFFIX} ${server_sources})
+target_link_libraries(redeclipse_server${BIN_SUFFIX} enet)
+set_target_properties(redeclipse_server${BIN_SUFFIX} PROPERTIES
+    COMPILE_FLAGS "-DSTANDALONE"
+)
+
+if(APPLE)
+    # include framework required in xcode/ code
+    find_library(COCOA_LIBRARY Cocoa)
+    target_link_libraries(redeclipse_client${BIN_SUFFIX} ${COCOA_LIBRARY})
+    target_link_libraries(redeclipse_server${BIN_SUFFIX} ${COCOA_LIBRARY})
+else(APPLE)
+    # add the genkey executable
+    add_executable(genkey${BIN_SUFFIX} ${genkey_sources})
+endif(APPLE)

--- a/src/enet/CMakeLists.txt
+++ b/src/enet/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 2.6)
+
+project(enet)
+
+# The "configure" step.
+include(CheckFunctionExists)
+include(CheckStructHasMember)
+include(CheckTypeSize)
+check_function_exists("fcntl" HAS_FCNTL)
+check_function_exists("poll" HAS_POLL)
+check_function_exists("getaddrinfo" HAS_GETADDRINFO)
+check_function_exists("getnameinfo" HAS_GETNAMEINFO)
+check_function_exists("gethostbyname_r" HAS_GETHOSTBYNAME_R)
+check_function_exists("gethostbyaddr_r" HAS_GETHOSTBYADDR_R)
+check_function_exists("inet_pton" HAS_INET_PTON)
+check_function_exists("inet_ntop" HAS_INET_NTOP)
+check_struct_has_member("struct msghdr" "msg_flags" "sys/types.h;sys/socket.h" HAS_MSGHDR_FLAGS)
+set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h" "sys/socket.h")
+check_type_size("socklen_t" HAS_SOCKLEN_T BUILTIN_TYPES_ONLY)
+unset(CMAKE_EXTRA_INCLUDE_FILES)
+
+if(HAS_FCNTL)
+    add_definitions(-DHAS_FCNTL=1)
+endif()
+if(HAS_POLL)
+    add_definitions(-DHAS_POLL=1)
+endif()
+if(HAS_GETNAMEINFO)
+    add_definitions(-DHAS_GETNAMEINFO=1)
+endif()
+if(HAS_GETADDRINFO)
+    add_definitions(-DHAS_GETADDRINFO=1)
+endif()
+if(HAS_GETHOSTBYNAME_R)
+    add_definitions(-DHAS_GETHOSTBYNAME_R=1)
+endif()
+if(HAS_GETHOSTBYADDR_R)
+    add_definitions(-DHAS_GETHOSTBYADDR_R=1)
+endif()
+if(HAS_INET_PTON)
+    add_definitions(-DHAS_INET_PTON=1)
+endif()
+if(HAS_INET_NTOP)
+    add_definitions(-DHAS_INET_NTOP=1)
+endif()
+if(HAS_MSGHDR_FLAGS)
+    add_definitions(-DHAS_MSGHDR_FLAGS=1)
+endif()
+if(HAS_SOCKLEN_T)
+    add_definitions(-DHAS_SOCKLEN_T=1)
+endif()
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+add_library(enet STATIC
+        callbacks.c
+        compress.c
+        host.c
+        list.c
+        packet.c
+        peer.c
+        protocol.c
+        unix.c
+        win32.c
+    )


### PR DESCRIPTION
As discussed previously, we should add CMake as an alternative to the classic Makefile for building Red Eclipse.

This PR deprecates the original [redeclipse-cmake](https://github.com/TheAssassin/redeclipse-cmake) project (except for the cross-compiling toolchains which might be added later to this repository, too).