### PR TITLE
Support redeclipse:// URLs as command line arguments

### DIFF
--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1056,6 +1056,38 @@ int main(int argc, char **argv)
     localconnect(false);
     resetfps();
 
+    // redeclipse:// URI support
+    // example: redeclipse://hostname:port/password
+    // (password is optional)
+    char reprotoprefix[] = "redeclipse://";
+    for (int i = 0; i < argc; i++) {
+        // check if string is prefixed with redeclipse://
+        if (strncmp(argv[i], reprotoprefix, strlen(reprotoprefix)) == 0) {
+            char *hoststr = NULL;
+            char *portstr = NULL;
+            char *passwordstr = NULL;
+
+            int port = SERVER_PORT;
+
+            hoststr = strtok(argv[i] + 13, ":");
+            portstr = strtok(NULL, "/");
+
+            if (portstr != NULL) {
+                passwordstr = strtok(NULL, "/");
+                port = strtol(portstr, NULL, 10);
+            }
+
+            if (hoststr == NULL) {
+                conoutf("\frMalformed commandline argument: %s", argv[i]);
+            } else {
+                connectserv(hoststr, port, passwordstr);
+            }
+        } else {
+            // only supported commandline argument type are redeclipse:// URIs
+            conoutf("\frMalformed commandline argument: %s", argv[i]);
+        }
+    }
+
     for(int frameloops = 0; ; frameloops = frameloops >= INT_MAX-1 ? MAXFPSHISTORY+1 : frameloops+1)
     {
         curtextscale = textscale;

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1089,11 +1089,6 @@ int main(int argc, char **argv)
             if(!host) conoutf("\frMalformed commandline argument: %s", argument);
             else connectserv(host, port, password);
         }
-        else
-        {
-            // only supported commandline argument type are redeclipse:// URIs
-            conoutf("\frMalformed commandline argument: %s", argument);
-        }
     }
 
     for(int frameloops = 0; ; frameloops = frameloops >= INT_MAX-1 ? MAXFPSHISTORY+1 : frameloops+1)

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1066,12 +1066,12 @@ int main(int argc, char **argv)
     for(int i = 1; i < argc; i++)
     {
         string argument;
-        strcpy(argument, argv[1]);
+        strcpy(argument, argv[i]);
 
         // check if string is prefixed with redeclipse://
         int offset = strlen(reprotoprefix);
 
-        if(strncmp(argv[i], reprotoprefix, offset) == 0)
+        if(strncmp(argument, reprotoprefix, offset) == 0)
         {
             char *password = strtok(argument + offset, "@");
 

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1057,34 +1057,40 @@ int main(int argc, char **argv)
     resetfps();
 
     // redeclipse:// URI support
-    // example: redeclipse://hostname:port/password
-    // (password is optional)
-    char reprotoprefix[] = "redeclipse://";
-    for (int i = 0; i < argc; i++) {
+    // examples:
+    // redeclipse://password@hostname:port
+    // redeclipse://hostname:port
+    // redeclipse://hostname
+    // (password and port are optional)
+    const char reprotoprefix[] = "redeclipse://";
+    for(int i = 1; i < argc; i++)
+    {
+        string argument;
+        strcpy(argument, argv[1]);
+
         // check if string is prefixed with redeclipse://
-        if (strncmp(argv[i], reprotoprefix, strlen(reprotoprefix)) == 0) {
-            char *hoststr = NULL;
-            char *portstr = NULL;
-            char *passwordstr = NULL;
+        int offset = strlen(reprotoprefix);
+
+        if(strncmp(argv[i], reprotoprefix, offset) == 0)
+        {
+            char *passwordstr = strtok(argument + offset, "@");
+
+            if(passwordstr) offset += strlen(passwordstr) + 1;
+
+            char *hoststr = strtok(argument + offset, ":");
+            char *portstr = strtok(NULL, "/");
 
             int port = SERVER_PORT;
 
-            hoststr = strtok(argv[i] + 13, ":");
-            portstr = strtok(NULL, "/");
+            if(portstr) port = strtol(portstr, NULL, 10);
 
-            if (portstr != NULL) {
-                passwordstr = strtok(NULL, "/");
-                port = strtol(portstr, NULL, 10);
-            }
-
-            if (hoststr == NULL) {
-                conoutf("\frMalformed commandline argument: %s", argv[i]);
-            } else {
-                connectserv(hoststr, port, passwordstr);
-            }
-        } else {
+            if(!hoststr) conoutf("\frMalformed commandline argument: %s", argument);
+            else connectserv(hoststr, port, passwordstr);
+        }
+        else
+        {
             // only supported commandline argument type are redeclipse:// URIs
-            conoutf("\frMalformed commandline argument: %s", argv[i]);
+            conoutf("\frMalformed commandline argument: %s", argv[1]);
         }
     }
 

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1073,24 +1073,26 @@ int main(int argc, char **argv)
 
         if(strncmp(argv[i], reprotoprefix, offset) == 0)
         {
-            char *passwordstr = strtok(argument + offset, "@");
+            char *password = strtok(argument + offset, "@");
 
-            if(passwordstr) offset += strlen(passwordstr) + 1;
+            if(password) offset += strlen(password) + 1;
 
             char *hoststr = strtok(argument + offset, ":");
             char *portstr = strtok(NULL, "/");
 
+            // skip trailing slashes
+            char *host = strtok(hoststr, "/");
             int port = SERVER_PORT;
 
             if(portstr) port = strtol(portstr, NULL, 10);
 
-            if(!hoststr) conoutf("\frMalformed commandline argument: %s", argument);
-            else connectserv(hoststr, port, passwordstr);
+            if(!host) conoutf("\frMalformed commandline argument: %s", argument);
+            else connectserv(host, port, password);
         }
         else
         {
             // only supported commandline argument type are redeclipse:// URIs
-            conoutf("\frMalformed commandline argument: %s", argv[1]);
+            conoutf("\frMalformed commandline argument: %s", argument);
         }
     }
 


### PR DESCRIPTION
This commit introduces the Red Eclipse URL scheme that can be used to start
Red Eclipse and immediately connect to a Red Eclipse server without having to
type a connect command or using the server browser to find a specific server.

The Red Eclipse URL scheme is defined as follows:

redeclipse://password@hostname:port
redeclipse://hostname:port
redeclipse://hostname

Slashes appended to the URL are ignored, hostname and port arguments are
optional.

The parser uses the same functionality as the /connect command, which means
it provides similar behavior.

Beware you need to configure your system to launch the Red Eclipse client
binary when redeclipse:// URLs are opened (e.g. in a Browser or a desktop
shortcut). You can find an example for Linux desktops in the community
repository (https://github.com/red-eclipse/community).