### PR TITLE
Support redeclipse:// URLs as command line arguments

### DIFF
--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1108,8 +1108,11 @@ int main(int argc, char **argv)
     localconnect(false);
     resetfps();
 
-    if(connecthost && *connecthost) connectserv(connecthost, connectport, connectpassword);
-    else conoutf("\frmalformed commandline argument: %s", reprotoarg);
+    if(reprotoarg)
+    {
+        if(connecthost && *connecthost) connectserv(connecthost, connectport, connectpassword);
+        else conoutf("\frmalformed commandline argument: %s", reprotoarg);
+    }
 
     // housekeeping
     if(connectstr)

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -925,8 +925,12 @@ int main(int argc, char **argv)
     char *initscript = NULL;
     initing = INIT_RESET;
 
-    // used to support redeclipse:// URIs
-    // see below for more information
+    // redeclipse:// URI support
+    // examples:
+    // redeclipse://password@hostname:port
+    // redeclipse://hostname:port
+    // redeclipse://hostname
+    // (password and port are optional)
     const char reprotoprefix[] = "redeclipse://";
     const int reprotolen = sizeof(reprotoprefix) - 1;
     char *reprotoarg = NULL;
@@ -978,12 +982,6 @@ int main(int argc, char **argv)
                 break;
         }
 
-        // redeclipse:// URI support
-        // examples:
-        // redeclipse://password@hostname:port
-        // redeclipse://hostname:port
-        // redeclipse://hostname
-        // (password and port are optional)
         // will only parse the first argument that is possibly a redeclipse:// URL argument and ignore any following
         else if(!strncmp(argv[i], reprotoprefix, reprotolen) && !reprotoarg)
         {
@@ -1110,8 +1108,6 @@ int main(int argc, char **argv)
     localconnect(false);
     resetfps();
 
-    // redeclipse:// URI support
-    // see above argument parser for more information
     if(connecthost && *connecthost) connectserv(connecthost, connectport, connectpassword);
     else conoutf("\frmalformed commandline argument: %s", reprotoarg);
 
@@ -1121,7 +1117,8 @@ int main(int argc, char **argv)
         delete[] connectstr;
         connectstr = NULL;
     }
-    if(reprotoarg) {
+    if(reprotoarg)
+    {
         delete[] reprotoarg;
         reprotoarg = NULL;
     }

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -924,6 +924,19 @@ int main(int argc, char **argv)
 
     char *initscript = NULL;
     initing = INIT_RESET;
+
+    // used to support redeclipse:// URIs
+    // see below for more information
+    const char reprotoprefix[] = "redeclipse://";
+    const int reprotolen = sizeof(reprotoprefix) - 1;
+    char *reprotoarg = NULL;
+    char *connectstr = NULL;
+    char *connectpassword = NULL;
+    char *connecthost = NULL;
+    int connectport = SERVER_PORT;
+
+    // try to parse home directory argument
+    // (has to be parsed first to be able to set the logfile path correctly)
     for(int i = 1; i<argc; i++)
     {
         if(argv[i][0]=='-') switch(argv[i][1])
@@ -933,8 +946,11 @@ int main(int argc, char **argv)
     }
     setlogfile("log.txt");
     execfile("init.cfg", false);
+
+    // parse the rest of the arguments
     for(int i = 1; i<argc; i++)
     {
+        // switches that can modify both server and client behavior
         if(argv[i][0]=='-') switch(argv[i][1])
         {
             case 'h': /* parsed first */ break;
@@ -961,6 +977,44 @@ int main(int argc, char **argv)
                 if(!serveroption(argv[i])) gameargs.add(argv[i]);
                 break;
         }
+
+        // redeclipse:// URI support
+        // examples:
+        // redeclipse://password@hostname:port
+        // redeclipse://hostname:port
+        // redeclipse://hostname
+        // (password and port are optional)
+        // will only parse the first argument that is possibly a redeclipse:// URL argument and ignore any following
+        else if(!strncmp(argv[i], reprotoprefix, reprotolen) && !reprotoarg)
+        {
+            reprotoarg = newstring(argv[i]);
+            connectstr = newstring(reprotoarg + reprotolen);
+
+            // check if there's actually text after the protocol prefix
+            if(!*connectstr) continue;
+
+            // skip trailing slashes (if any)
+            char* slashchr = strchr(connectstr, '/');
+            if(slashchr) *slashchr = '\0';
+
+            connecthost = strchr(connectstr, '@');
+            if(connecthost)
+            {
+                connectpassword = connectstr;
+                *connecthost++ = '\0';
+            }
+            else connecthost = connectstr;
+
+            char *portbuf = strchr(connecthost, ':');
+            if(portbuf)
+            {
+                *portbuf++ = '\0';
+                connectport = parseint(portbuf);
+                if(!connectport) connectport = SERVER_PORT;
+            }
+        }
+
+        // unmatched arguments
         else gameargs.add(argv[i]);
     }
 
@@ -1055,6 +1109,22 @@ int main(int argc, char **argv)
 
     localconnect(false);
     resetfps();
+
+    // redeclipse:// URI support
+    // see above argument parser for more information
+    if(connecthost && *connecthost) connectserv(connecthost, connectport, connectpassword);
+    else conoutf("\frmalformed commandline argument: %s", reprotoarg);
+
+    // housekeeping
+    if(connectstr)
+    {
+        delete[] connectstr;
+        connectstr = NULL;
+    }
+    if(reprotoarg) {
+        delete[] reprotoarg;
+        reprotoarg = NULL;
+    }
 
     for(int frameloops = 0; ; frameloops = frameloops >= INT_MAX-1 ? MAXFPSHISTORY+1 : frameloops+1)
     {


### PR DESCRIPTION
This commit introduces the Red Eclipse URL scheme that can be used to start Red Eclipse and immediately connect to a Red Eclipse server without having to type a connect command or using the server browser to find a specific server.

The Red Eclipse URL scheme is defined as follows:

redeclipse://password@hostname:port
redeclipse://hostname:port
redeclipse://hostname

Slashes appended to the URL are ignored, password and port arguments are optional. Spaces are allowed after the prefix (...://), but they are only useful in the password part.

The parser uses the same functionality as the /connect command, which means it provides similar behavior.

Beware you need to configure your system to launch the Red Eclipse client binary when redeclipse:// URLs are opened (e.g. in a Browser or a desktop shortcut). You can find an example for Linux desktops in the community repository (https://github.com/red-eclipse/community).

This is the third attempt to get this merged. See PRs https://github.com/red-eclipse/base/pull/631 and https://github.com/red-eclipse/base/pull/632 for more information on the other ones.