### PR TITLE
Include directory enet/include in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_subdirectory(enet)
 
 # configure local includes
 include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/enet/include
     ${CMAKE_CURRENT_SOURCE_DIR}/engine
     ${CMAKE_CURRENT_SOURCE_DIR}/game
     ${CMAKE_CURRENT_SOURCE_DIR}/include


### PR DESCRIPTION
cube.h tries to include enet.h at line 61 but that gives a compiler error because the compiler doesn't look in the right directory.