### PR TITLE
Make player preview rotation controllable

### DIFF
--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1606,9 +1606,10 @@ namespace modelpreview
     }
 }
 
-vec calcmodelpreviewpos(const vec &radius, float &yaw)
+vec calcmodelpreviewpos(const vec &radius, float &yaw, float setyaw)
 {
-    yaw = fmod(lastmillis/10000.0f*360.0f, 360.0f);
+    if(setyaw >= 0) yaw = fmod(setyaw, 360.0f);
+    else yaw = fmod(lastmillis/10000.0f*360.0f, 360.0f);
     float dist = 1.05f*max(radius.magnitude2()/aspect, radius.magnitude())/sinf(fovy/2*RAD);
     return vec(0, dist, 0).rotate_around_x(camera1->pitch*RAD);
 }

--- a/src/engine/ui.cpp
+++ b/src/engine/ui.cpp
@@ -470,9 +470,10 @@ struct gui : guient
             }
             int x1 = int(floor(screenw*(xi*uiscale.x+uiorigin.x))), y1 = int(floor(screenh*(1 - ((yi+ys)*uiscale.y+uiorigin.y)))),
                 x2 = int(ceil(screenw*((xi+xs)*uiscale.x+uiorigin.x))), y2 = int(ceil(screenh*(1 - (yi*uiscale.y+uiorigin.y))));
+            float setyaw = hit ? (xi - hitx + xs) * 360.0f / xs : -1;
             glDisable(GL_BLEND);
             modelpreview::start(x1, y1, x2-x1, y2-y1, overlaid);
-            game::renderplayerpreview(model, color, team, weap, vanity, scale, blend);
+            game::renderplayerpreview(model, color, team, weap, vanity, scale, blend, setyaw);
             modelpreview::end();
             hudshader->set();
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3628,7 +3628,7 @@ namespace game
         if(rendernormally && early) rendercheck(focus, third);
     }
 
-    void renderplayerpreview(int model, int color, int team, int weap, const char *vanity, float scale, float blend)
+    void renderplayerpreview(int model, int color, int team, int weap, const char *vanity, float scale, float blend, float yaw)
     {
         static gameent *previewent = NULL;
         if(!previewent)
@@ -3644,7 +3644,7 @@ namespace game
         float height = previewent->height + previewent->aboveeye,
               zrad = height/2;
         vec2 xyrad = vec2(previewent->xradius, previewent->yradius).max(height/4);
-        previewent->o = calcmodelpreviewpos(vec(xyrad, zrad), previewent->yaw).addz(previewent->height - zrad);
+        previewent->o = calcmodelpreviewpos(vec(xyrad, zrad), previewent->yaw, yaw).addz(previewent->height - zrad);
         previewent->colour = color;
         previewent->model = model;
         previewent->team = clamp(team, 0, int(T_MULTI));

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -230,7 +230,7 @@ extern vec worldpos, camdir, camright, camup;
 extern void getscreenres(int &w, int &h);
 extern void gettextres(int &w, int &h);
 
-extern vec calcmodelpreviewpos(const vec &radius, float &yaw);
+extern vec calcmodelpreviewpos(const vec &radius, float &yaw, float setyaw = -1);
 
 extern vec minimapcenter, minimapradius, minimapscale;
 extern void bindminimap();

--- a/src/shared/igame.h
+++ b/src/shared/igame.h
@@ -120,7 +120,7 @@ namespace game
     extern void findanims(const char *pattern, vector<int> &anims);
     extern void render();
     extern void renderavatar(bool early = false, bool project = false);
-    extern void renderplayerpreview(int model = 0, int color = 0xA0A0A0, int team = 0, int weap = 0, const char *vanity = "", float scale = 1, float blend = 1);
+    extern void renderplayerpreview(int model = 0, int color = 0xA0A0A0, int team = 0, int weap = 0, const char *vanity = "", float scale = 1, float blend = 1, float yaw = -1);
     extern bool thirdpersonview(bool viewonly = false, physent *d = NULL);
     extern vec thirdpos(const vec &pos, float yaw, float pitch, float dist = 1, float side = 0);
     extern vec camerapos(physent *d, bool hasfoc = false, bool hasyp = false, float yaw = 0, float pitch = 0);


### PR DESCRIPTION
You can control it by hovering with the mouse cursor and when you leave it, it continues normal rotation.

I think this fixes #44 