### PR TITLE
Clear teams before initial balancing.

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -1638,6 +1638,7 @@ namespace server
                         clientinfo *cp = clients[j];
                         if(!cp->team || cp->state == CS_SPECTATOR || cp->actortype > A_PLAYER) continue;
                         pool.add(cp);
+                        setteam(cp, T_NEUTRAL, 0, false);
                     }
                     pool.sort(balancecmp);
                     loopvj(pool)


### PR DESCRIPTION
This change will set all waiting player's teams to neutral before balancing, allowing `chooseteam` to operate without counting them as having joined a team until they are properly sorted into one.