### PR TITLE
Fix infinite impulse glitch

### DIFF
--- a/src/game/projs.cpp
+++ b/src/game/projs.cpp
@@ -1876,9 +1876,6 @@ namespace projs
                     }
                     e->vel = vec(yaw*RAD, pitch*RAD).mul(mag).add(keepvel);
                     e->doimpulse(cost, IM_T_GRAB, lastmillis);
-                    e->turnmillis = PHYSMILLIS;
-                    e->turnside = 0;
-                    e->turnyaw = e->turnroll = 0;
                     client::addmsg(N_SPHY, "ri2", e->clientnum, SPHY_GRAB);
                     game::impulseeffect(e);
                     game::footstep(e);


### PR DESCRIPTION
Related forum topic http://redeclipse.net/forum/viewtopic.php?f=7&t=999&p=9127
Helps to improve time on absorption by a lot. Makes camping by infinite wallrunning possible. SniperGoth, and people in the forum topic think this should be fixed and is a potential game breaker.