### PR TITLE
Limit the sent branch length to 16 characters.

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -31,6 +31,8 @@ extern const char *platnames[MAX_PLATFORMS], *platlongnames[MAX_PLATFORMS];
 #define plat_name(a) (sup_platform(a) ? platnames[a] : "unk")
 #define plat_longname(a) (sup_platform(a) ? platlongnames[a] : "unknown")
 
+#define MAXBRANCHLEN 16
+
 extern const char *timestr(int dur, int style = 0);
 
 extern vector<char *> gameargs;

--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -1702,7 +1702,8 @@ void setverinfo(const char *bin)
     string buf;
     setvar("versioncrc", crcfile(bin));
     const char *vbranch = getenv(sup_var("BRANCH"));
-    setsvar("versionbranch", vbranch && *vbranch ? vbranch : "none");
+    string truncatedbranch; copystring(truncatedbranch, vbranch && *vbranch ? vbranch : "none", MAXBRANCHLEN + 1);
+    setsvar("versionbranch", truncatedbranch);
 #ifdef WIN32
     const char *suser = getenv("USERNAME");
 #else

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -192,6 +192,7 @@ extern enttypes enttype[];
 #endif
 
 #define MAXNAMELEN 24
+#define MAXBRANCHLEN 16
 enum { SAY_NONE = 0, SAY_ACTION = 1<<0, SAY_TEAM = 1<<1, SAY_WHISPER = 1<<2, SAY_NUM = 3 };
 
 enum {
@@ -490,7 +491,7 @@ struct verinfo
         gpuglslver = getint(p);
         crc = getint(p);
         if(branch) delete[] branch;
-        getstring(text, p); branch = newstring(text);
+        getstring(text, p); branch = newstring(text, MAXBRANCHLEN);
         if(gpuvendor) delete[] gpuvendor;
         getstring(text, p); gpuvendor = newstring(text);
         if(gpurenderer) delete[] gpurenderer;
@@ -529,7 +530,7 @@ struct verinfo
         gpuglslver = v.gpuglslver;
         crc = v.crc;
         if(branch) delete[] branch;
-        branch = newstring(v.branch ? v.branch : "");
+        branch = newstring(v.branch ? v.branch : "", MAXBRANCHLEN);
         if(gpuvendor) delete[] gpuvendor;
         gpuvendor = newstring(v.gpuvendor ? v.gpuvendor : "");
         if(gpurenderer) delete[] gpurenderer;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -192,7 +192,6 @@ extern enttypes enttype[];
 #endif
 
 #define MAXNAMELEN 24
-#define MAXBRANCHLEN 16
 enum { SAY_NONE = 0, SAY_ACTION = 1<<0, SAY_TEAM = 1<<1, SAY_WHISPER = 1<<2, SAY_NUM = 3 };
 
 enum {


### PR DESCRIPTION
This will cut off branch text longer than `MAXBRANCHLEN` so that clients will not try to display all of it as described in #656.