### PR TITLE
Add DISC_AUTH for when clients authenticate with the same handle.

### DIFF
--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -55,7 +55,7 @@ SVAR(IDF_READONLY, systemhost, "unknown");
 
 VAR(0, rehashing, 1, 0, -1);
 
-const char * const disc_reasons[] = { "normal", "end of packet", "client num", "user was kicked", "message error", "address is banned", "server is in private mode", "server is password protected", "server requires pure official builds", "server is at maximum capacity", "server and client are incompatible", "connection timed out", "packet overflow", "server shutting down", "hostname lookup failure" };
+const char * const disc_reasons[] = { "normal", "end of packet", "client num", "user was kicked", "message error", "address is banned", "server is in private mode", "server is password protected", "server requires pure official builds", "server is at maximum capacity", "server and client are incompatible", "connection timed out", "packet overflow", "server shutting down", "hostname lookup failure", "client with same handle authenticated" };
 
 SVAR(IDF_PERSIST, logtimeformat, "%Y-%m-%d %H:%M.%S");
 VAR(IDF_PERSIST, logtimelocal, 0, 1, 1); // use clockoffset to localise

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -5711,7 +5711,7 @@ namespace server
         if(ci->handle[0]) // kick old logins
         {
             loopvrev(clients) if(clients[i] != ci && clients[i]->handle[0] && !strcmp(clients[i]->handle, ci->handle))
-                disconnect_client(clients[i]->clientnum, DISC_KICK);
+                disconnect_client(clients[i]->clientnum, DISC_AUTH);
         }
         sendwelcome(ci);
         if(restorescore(ci)) sendresume(ci);

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -427,7 +427,7 @@ extern void twitchragdoll(dynent *d, float vel);
 #define MAXCLIENTS 256                  // in a multiplayer game, can be arbitrarily changed
 #define MAXTRANS 5000                  // max amount of data to swallow in 1 go
 
-enum { DISC_NONE = 0, DISC_EOP, DISC_CN, DISC_KICK, DISC_MSGERR, DISC_IPBAN, DISC_PRIVATE, DISC_PASSWORD, DISC_PURE, DISC_MAXCLIENTS, DISC_INCOMPATIBLE, DISC_TIMEOUT, DISC_OVERFLOW, DISC_SHUTDOWN, DISC_HOSTFAIL, DISC_NUM };
+enum { DISC_NONE = 0, DISC_EOP, DISC_CN, DISC_KICK, DISC_MSGERR, DISC_IPBAN, DISC_PRIVATE, DISC_PASSWORD, DISC_PURE, DISC_MAXCLIENTS, DISC_INCOMPATIBLE, DISC_TIMEOUT, DISC_OVERFLOW, DISC_SHUTDOWN, DISC_HOSTFAIL, DISC_AUTH, DISC_NUM };
 
 extern void *getinfo(int i);
 extern const char *gethostname(int i);


### PR DESCRIPTION
This replaces the old DISC_KICK method in this situation, clarifying what is happening to those reading the message.