### PR TITLE
Improve IRC and log privacy

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -6,7 +6,6 @@
 
 extern int version, versioning, versionmajor, versionminor, versionpatch, versionplatform, versionarch, versionisserver, versioncrc;
 extern char *versionstring, *versionname, *versionuname, *versionvname, *versionrelease, *versionurl, *versionmaster, *versionplatname, *versionplatlongname, *versionbranch;
-extern char *systemuser, *systemhost;
 #define CUR_VER_MAKE(a,b,c) (((a)<<16) | ((b)<<8) | (c))
 #define CUR_VER CUR_VER_MAKE(VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 #define CUR_VERSION (VERSION_MAJOR*100)+(VERSION_MINOR*10)+VERSION_PATCH

--- a/src/engine/irc.cpp
+++ b/src/engine/irc.cpp
@@ -920,7 +920,7 @@ void ircslice()
                     if(*n->passkey) ircsend(n, "PASS %s", n->passkey);
                     copystring(n->nick, n->mnick);
                     ircsend(n, "NICK %s", n->mnick);
-                    if(!*n->ident) copystring(n->ident, systemuser);
+                    if(!*n->ident) copystring(n->ident, VERSION_UNAME);
                     ircsend(n, "USER %s +iw %s :%s v%s-%s%d-%s (%s)", n->ident, n->ident, versionname, versionstring, versionplatname, versionarch, versionbranch, versionrelease);
                     n->lastnick = clocktime;
                     n->state = IRC_CONN;

--- a/src/engine/irc.cpp
+++ b/src/engine/irc.cpp
@@ -920,7 +920,7 @@ void ircslice()
                     if(*n->passkey) ircsend(n, "PASS %s", n->passkey);
                     copystring(n->nick, n->mnick);
                     ircsend(n, "NICK %s", n->mnick);
-                    if(!*n->ident) copystring(n->ident, VERSION_UNAME);
+                    if(!*n->ident) copystring(n->ident, versionuname);
                     ircsend(n, "USER %s +iw %s :%s v%s-%s%d-%s (%s)", n->ident, n->ident, versionname, versionstring, versionplatname, versionarch, versionbranch, versionrelease);
                     n->lastnick = clocktime;
                     n->state = IRC_CONN;

--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -50,8 +50,6 @@ VAR(IDF_READONLY, versionisserver, 0, 0, 1);
 #endif
 ICOMMAND(0, platname, "ii", (int *p, int *g), result(*p >= 0 && *p < MAX_PLATFORMS ? (*g!=0 ? plat_longname(*p) : plat_name(*p)) : ""));
 
-SVAR(IDF_READONLY, systemhost, "unknown");
-
 VAR(0, rehashing, 1, 0, -1);
 
 const char * const disc_reasons[] = { "normal", "end of packet", "client num", "user was kicked", "message error", "address is banned", "server is in private mode", "server is password protected", "server requires pure official builds", "server is at maximum capacity", "server and client are incompatible", "connection timed out", "packet overflow", "server shutting down", "hostname lookup failure", "client with same handle authenticated" };

--- a/src/engine/server.cpp
+++ b/src/engine/server.cpp
@@ -50,7 +50,6 @@ VAR(IDF_READONLY, versionisserver, 0, 0, 1);
 #endif
 ICOMMAND(0, platname, "ii", (int *p, int *g), result(*p >= 0 && *p < MAX_PLATFORMS ? (*g!=0 ? plat_longname(*p) : plat_name(*p)) : ""));
 
-SVAR(IDF_READONLY, systemuser, "none");
 SVAR(IDF_READONLY, systemhost, "unknown");
 
 VAR(0, rehashing, 1, 0, -1);
@@ -1241,7 +1240,7 @@ static void setupwindow(const char *title)
     atexit(cleanupwindow);
 
     if(!setupsystemtray(WM_APP)) fatal("failed adding to system tray");
-    conoutf("identity: %s@%s v%s-%s%d-%s %s (%s) [0x%.8x]", systemuser, systemhost, versionstring, versionplatname, versionarch, versionbranch, versionisserver ? "server" : "client", versionrelease, versioncrc);
+    conoutf("version: %s-%s%d-%s %s (%s) [0x%.8x]", versionstring, versionplatname, versionarch, versionbranch, versionisserver ? "server" : "client", versionrelease, versioncrc);
 }
 
 static char *parsecommandline(const char *src, vector<char *> &args)
@@ -1437,7 +1436,7 @@ void setupserver()
 
 void initgame()
 {
-    conoutf("identity: %s@%s v%s-%s%d-%s %s (%s) [0x%.8x]", systemuser, systemhost, versionstring, versionplatname, versionarch, versionbranch, versionisserver ? "server" : "client", versionrelease, versioncrc);
+    conoutf("version: %s-%s%d-%s %s (%s) [0x%.8x]", versionstring, versionplatname, versionarch, versionbranch, versionisserver ? "server" : "client", versionrelease, versioncrc);
     server::start();
     loopv(gameargs)
     {
@@ -1703,31 +1702,6 @@ void setverinfo(const char *bin)
     setvar("versioncrc", crcfile(bin));
     const char *vbranch = getenv(sup_var("BRANCH"));
     setsvar("versionbranch", vbranch);
-#ifdef WIN32
-    const char *suser = getenv("USERNAME");
-#else
-    const char *suser = getenv("USER");
-    if(!suser || !*suser)
-    { // only fall back to this if the variable isn't exported
-        passwd *p = getpwuid(geteuid());
-        if(p)
-        {
-            copystring(buf, p->pw_name);
-            suser = buf;
-        }
-    }
-#endif
-    setsvar("systemuser", suser && *suser ? suser : "none");
-#ifdef WIN32
-    const char *shost = getenv("COMPUTERNAME");
-#else
-    const char *shost = getenv("HOSTNAME");
-#endif
-    if(!shost || !*shost)
-    { // only fall back to this if the variable isn't exported
-        if(!gethostname(buf, sizeof(string)-1) && *buf) shost = buf;
-    }
-    setsvar("systemhost", shost && *shost ? shost : "unknown");
 }
 
 volatile bool fatalsig = false;


### PR DESCRIPTION
Until now, a user's system's username and hostname have been written to the
log files and were used as identification for the in-game IRC client.

Both is a privacy issue. Being in the log, if an unexperienced user pastes
their log on the internet, both information is shared with third parties.
Using it for the IRC client is even more dangerous, because if some user
accidentally pressed I ingame, the username would be leaked automatically.
As the user is not even informed about this, it might even be illegal in
several countries.

As a result, systemuser and systemhost variables have been removed as they
would no longer be used in the codebase.

The issue has previously been discussed on the forums more than a year ago
(http://redeclipse.net/forum/viewtopic.php?f=7&t=814), but resulted in some
"might be useful". Apparently, this is not an excuse for creating potential
privacy issues.