### PR TITLE
Fix wrong desktop entry version

### DIFF
--- a/src/install/nix/redeclipse.desktop.am
+++ b/src/install/nix/redeclipse.desktop.am
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=1.0
+Version=1.2
 Name=Red Eclipse
 GenericName=First-person shooter game
 GenericName[es]=Juego de tiros en primera persona


### PR DESCRIPTION
The desktop file needs to follow at least version 1.1. Since the "keywords" key was added in 1.1: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#idm140271348128080
And because 1.2 does not add something, this file is not following, we can use the 1.2 version.