### PR TITLE
Add a variable to toggle MOUSE3 escaping the current UI.

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -588,6 +588,7 @@ setdesc "searchbinds" "finds key binds for a given action;^nthis is used by the 
 setdesc "searcheditbinds" "finds edit key binds for a given action;^nthis is used by the dobindsearch alias" "action [formatting options]"
 setdesc "searchspecbinds" "finds spectator key binds for a given action;^nthis is used by the dobindsearch alias" "action [formatting options]"
 setdesc "dobindsearch" "prints out a nicely formatted string with the key binds for a given action;^naction is the action to search for,^n[mode] can be edit or spec to search for the corresponding mode specific binds." "key [mode]"
+setdesc "uimouse3esc" "escape the current ui when MOUSE3 is pressed" "value"
 
 setdesc "loop" "executes body with var incremented from 0 to count-1;^nexample: loop i 10 [ echo $i ]" "var count body"
 setdesc "loopconcat" "returns a string with the result of the body concatenated with var incremented from 0 to count-1;^nexample: loopconcat i 10 [ result $i ]" "var count body"

--- a/src/engine/ui.cpp
+++ b/src/engine/ui.cpp
@@ -17,6 +17,8 @@ namespace UI
 
     FVAR(IDF_PERSIST, uitipoffset, 0, 0.005f, 1);
 
+    VAR(IDF_PERSIST, uimouse3esc, 0, 1, 1);
+
     static void quads(float x, float y, float w, float h, float tx = 0, float ty = 0, float tw = 1, float th = 1)
     {
         gle::attribf(x,   y);   gle::attribf(tx,    ty);
@@ -3809,7 +3811,7 @@ namespace UI
         {
             case SDLK_ESCAPE: action = isdown ? STATE_ESC_PRESS : STATE_ESC_RELEASE; hold = STATE_ESC_HOLD; break;
             case -1: action = isdown ? STATE_PRESS : STATE_RELEASE; hold = STATE_HOLD; break;
-            case -2: action = isdown ? STATE_ESC_PRESS : STATE_ESC_RELEASE; hold = STATE_ESC_HOLD; break;
+            case -2: if(uimouse3esc) { action = isdown ? STATE_ESC_PRESS : STATE_ESC_RELEASE; hold = STATE_ESC_HOLD; } break;
             case -3: action = isdown ? STATE_ALT_PRESS : STATE_ALT_RELEASE; hold = STATE_ALT_HOLD; break;
             case -4: action = STATE_SCROLL_UP; break;
             case -5: action = STATE_SCROLL_DOWN; break;


### PR DESCRIPTION
Variable name and usage description might need some tweaking, let me know if they do.