### PR TITLE
Do not display demo errors when just loading the maps cache.

### DIFF
--- a/config/ui/maps.cfg
+++ b/config/ui/maps.cfg
@@ -7,7 +7,7 @@ ui_maps_cache = [
     looplist ui_maps_cache_lcurmap $ui_maps_cache_filelist [mapcscan [maps/@[ui_maps_cache_lcurmap]]]
     mapcsort
     ui_maps_cache_filelist = (listfiles demos dmo)
-    looplist ui_maps_cache_lcurmap $ui_maps_cache_filelist [demoscan [demos/@[ui_maps_cache_lcurmap].dmo]]
+    looplist ui_maps_cache_lcurmap $ui_maps_cache_filelist [demoscan [demos/@[ui_maps_cache_lcurmap].dmo] 1]
     demosort
 ]
 ui_maps_cache
@@ -289,7 +289,7 @@ uimenu "maps" "Select a Map and Mode" "textures/maps" [
                                 ui_maps_exec $ui_maps_cur $ui_maps_mode $ui_maps_muts
                             ] 0 [] (|| (< $ui_maps_mode 0) (=s $ui_maps_cur "")) $ui_padbutton [
                                 ui_maps_fav = (format "%1.%2.%3" $ui_maps_cur $ui_maps_mode $ui_maps_muts)
-                                gamefavs = (concat $ui_maps_fav (listdel $gamefavs $ui_maps_fav)) 
+                                gamefavs = (concat $ui_maps_fav (listdel $gamefavs $ui_maps_fav))
                             ] $ui_default
                         ]
                     ]

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -203,7 +203,7 @@ namespace client
     vector<demoinfo> demoinfos;
     vector<char *> faildemos;
 
-    int scandemo(const char *name)
+    int scandemo(const char *name, bool quiet = false)
     {
         if(!name || !*name) return -1;
         loopv(demoinfos) if(!strcmp(demoinfos[i].file, name)) return i;
@@ -229,14 +229,14 @@ namespace client
         delete f;
         if(msg[0])
         {
-            conoutft(CON_INFO, "%s", msg);
+            if(!quiet) conoutft(CON_INFO, "%s", msg);
             demoinfos.pop();
             faildemos.add(newstring(name));
             return -1;
         }
         return num;
     }
-    ICOMMAND(0, demoscan, "s", (char *name), intret(scandemo(name)));
+    ICOMMAND(0, demoscan, "si", (char *name, int *quiet), intret(scandemo(name, *quiet)));
 
     void resetdemos(bool all)
     {


### PR DESCRIPTION
Several somewhat spammy errors currently appear in the console during cache filling when there are incompatible demos found, this quiets those errors since incompatibility should be indicated in the selection ui.