### PR TITLE
Do not fail on old versions when scanning server demos.

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2457,8 +2457,6 @@ namespace server
         else
         {
             lilswap(&d.hdr.gamever, 4);
-            if(d.hdr.gamever!=VERSION_GAME)
-                formatstring(msg, "\frDemo \fs\fc%s\fS requires \fs\fc%s\fS version of %s", name, d.hdr.gamever<VERSION_GAME ? "an older" : "a newer", versionname);
         }
         delete f;
         if(msg[0])


### PR DESCRIPTION
Currently the server will not remove old demos if their version is non-compatible even though it does not need to actually parse the entire demo, this will remove the game version check so that `demoserverkeeptime` applies to all demo files.