### PR TITLE
Automatically build AppImages on Semaphore

### DIFF
--- a/src/semaphore.sh
+++ b/src/semaphore.sh
@@ -106,11 +106,7 @@ semabuild_appimage() {
     echo "building AppImage..."
     git clone https://github.com/TheAssassin/redeclipse-appimage.git
     cd redeclipse-appimage
-    git_rev=$(git rev-parse --short HEAD)
-    export VERSION=1.5.9-alpha-$git_rev
-    export BRANCH=$git_rev
-    docker-compose up || return 1
-    docker-compose down || return 1
+    bash build-with-docker.sh
     return 0
 }
 

--- a/src/semaphore.sh
+++ b/src/semaphore.sh
@@ -102,8 +102,18 @@ semabuild_deploy() {
     return 0
 }
 
+semabuild_appimage() {
+    echo "building AppImage..."
+    git clone https://github.com/TheAssassin/redeclipse-appimage.git
+    cd redeclipse-appimage
+    docker-compose up || return 1
+    docker-compose down || return 1
+    return 0
+}
+
 semabuild_setup || exit 1
 semabuild_process || exit 1
+semabuild_appimage || exit 1
 if [ "${SEMABUILD_DEPLOY}" = "true" ]; then
     semabuild_deploy || exit 1
 fi

--- a/src/semaphore.sh
+++ b/src/semaphore.sh
@@ -106,6 +106,9 @@ semabuild_appimage() {
     echo "building AppImage..."
     git clone https://github.com/TheAssassin/redeclipse-appimage.git
     cd redeclipse-appimage
+    git_rev=$(git rev-parse --short HEAD)
+    export VERSION=1.5.9-alpha-$git_rev
+    export BRANCH=$git_rev
     docker-compose up || return 1
     docker-compose down || return 1
     return 0

--- a/src/semaphore.sh
+++ b/src/semaphore.sh
@@ -105,8 +105,9 @@ semabuild_deploy() {
 semabuild_appimage() {
     echo "building AppImage..."
     git clone https://github.com/TheAssassin/redeclipse-appimage.git
-    cd redeclipse-appimage
-    bash build-with-docker.sh
+    export BRANCH=${BRANCH_NAME}
+    export COMMIT=$(git rev-parse HEAD)
+    (cd redeclipse-appimage && bash build-with-docker.sh)
     return 0
 }
 


### PR DESCRIPTION
The PR introduces auto builds for bleeding-edge AppImages that can be downloaded by users who want to try out the latest features. It uses https://github.com/TheAssassin/redeclipse-appimage and a Docker container to build the AppImage in a Debian wheezy container.
The only feature missing is some kind of deployment to a server where users can download it. I guess @qreeves has to add that though, as I don't know much about his infrastructure.
I can also provide some space on my server for that.