### PR TITLE
Use CMAKE_BUILD_TYPE to set compiler flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,9 +8,9 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # set compile options
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -ffast-math -fno-exceptions -fno-rtti")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fomit-frame-pointer -ffast-math -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -ffast-math -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fomit-frame-pointer")
 
 # Use pkg-config to configure dependencies later
 find_package(PkgConfig REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,16 @@
 cmake_minimum_required(VERSION 2.8.11)
 
+# set default build type
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (release or debug)" FORCE)
+endif()
+
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
 # set compile options
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fomit-frame-pointer -ffast-math -Wall -fsigned-char -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -ffast-math -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fomit-frame-pointer -ffast-math -fno-exceptions -fno-rtti")
 
 # Use pkg-config to configure dependencies later
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
This makes it possible to build with debug information and without optimization using this command:

```
cmake -DCMAKE_BUILD_TYPE=debug
```

If no build type is specified then release is used.