### PR TITLE
Remove duplicate savedscore functions

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2781,7 +2781,7 @@ namespace server
         return false;
     }
 
-    savedscore *findscore(vector<savedscore>& scores, clientinfo *ci, bool insert)
+    savedscore *findscore(vector<savedscore> &scores, clientinfo *ci, bool insert)
     {
         uint ip = getclientip(ci->clientnum);
         if(!ip && !ci->handle[0]) return NULL;


### PR DESCRIPTION
Remove `findstatsscore` and add parameter to `findscore` to operate on both `savedscores` and `savedstatsscores` vectors. Remove `scorestatscmp` and update `scorecmp` to behave like `scorestatscmp` which provides better detection of whether it's the same player or not.