### PR TITLE
Use temp directory instead of maps directory for sent CRC-specified maps.

### DIFF
--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -95,7 +95,11 @@ void setnames(const char *fname, int type, int crc)
 
     if(strpbrk(fn, "/\\")) copystring(mn, fn);
     else formatstring(mn, "%s/%s", mapdirs[maptype].name, fn);
-    setsvar("mapname", mn);
+
+    // Any map with a CRC must be placed in temp/, so we add the prefix if it does not already exist.
+    if(crc != 0 && strstr(mn, "temp/") != mn && strstr(mn, "temp\\") != mn) prependstring(mn, "temp/");
+    // Set the mapname variable. If there is no CRC, we need to remove the temp/ prefix.
+    setsvar("mapname", (crc == 0 && strstr(mn, "temp/") == mn) ? (mn + 5) : mn);
 
     formatstring(mf, "%s%s", mapname, mapexts[maptype].name);
     setsvar("mapfile", mf);

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -99,7 +99,7 @@ void setnames(const char *fname, int type, int crc)
     // Any map with a CRC must be placed in temp/, so we add the prefix if it does not already exist.
     if(crc != 0 && strstr(mn, "temp/") != mn && strstr(mn, "temp\\") != mn) prependstring(mn, "temp/");
     // Set the mapname variable. If there is no CRC, we need to remove the temp/ prefix.
-    setsvar("mapname", (crc == 0 && strstr(mn, "temp/") == mn) ? (mn + 5) : mn);
+    setsvar("mapname", (crc == 0 && (strstr(mn, "temp/") == mn || strstr(mn, "temp\\") == mn)) ? (mn + 5) : mn);
 
     formatstring(mf, "%s%s", mapname, mapexts[maptype].name);
     setsvar("mapfile", mf);

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1602,7 +1602,7 @@ namespace client
                 len -= p.length();
                 if(filetype < 0 || filetype >= SENDMAP_MAX || len <= 0) break;
                 if(!*fname) copystring(fname, "maps/untitled");
-                defformatstring(ffile, strstr(fname, "maps/")==fname || strstr(fname, "maps\\")==fname ? "%s_0x%.8x" : "maps/%s_0x%.8x", fname, filecrc);
+                defformatstring(ffile, strstr(fname, "maps/")==fname || strstr(fname, "maps\\")==fname ? "temp/%s_0x%.8x" : "temp/maps/%s_0x%.8x", fname, filecrc);
                 defformatstring(ffext, "%s.%s", ffile, sendmaptypes[filetype]);
                 stream *f = openfile(ffext, "wb");
                 if(!f)

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1602,7 +1602,9 @@ namespace client
                 len -= p.length();
                 if(filetype < 0 || filetype >= SENDMAP_MAX || len <= 0) break;
                 if(!*fname) copystring(fname, "maps/untitled");
-                defformatstring(ffile, strstr(fname, "maps/")==fname || strstr(fname, "maps\\")==fname ? "temp/%s_0x%.8x" : "temp/maps/%s_0x%.8x", fname, filecrc);
+                // Remove any temp/ prefix from file name before testing and rebuilding.
+                defformatstring(nfname, "%s", (strstr(fname, "temp/") == fname || strstr(fname, "temp\\") == fname) ? fname + 5 : fname);
+                defformatstring(ffile, strstr(nfname, "maps/")==nfname || strstr(nfname, "maps\\")==nfname ? "temp/%s_0x%.8x" : "temp/maps/%s_0x%.8x", nfname, filecrc);
                 defformatstring(ffext, "%s.%s", ffile, sendmaptypes[filetype]);
                 stream *f = openfile(ffext, "wb");
                 if(!f)


### PR DESCRIPTION
This PR changes the map downloading system to use the `temp/` directory for storing CRC-downloaded map files, freeing `maps/` for solely `savemap`ed maps and fixing #626.

## Potential Additions

* Automatic cleaning of old files after some time, perhaps just through their modification timestamp.

Fixes #626 