### PR TITLE
Isolate obit vars from affecting the rest of the obit message with formatting codes.

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1500,6 +1500,7 @@ namespace game
         d->lastattacker = v->clientnum;
         if(d == v)
         {
+            concatstring(d->obit, "\fs");
             if(!actor[d->actortype].living) concatstring(d->obit, obitdestroyed);
             else if(!obitverbose) concatstring(d->obit, obitdied);
             else if(flags&HIT_SPAWN) concatstring(d->obit, obitspawn);
@@ -1516,10 +1517,11 @@ namespace game
             else if(d->obliterated) concatstring(d->obit, obitobliterated);
             else if(d->headless) concatstring(d->obit, obitheadless);
             else concatstring(d->obit, obitsuicide);
+            concatstring(d->obit, "\fS");
         }
         else
         {
-            concatstring(d->obit, "was ");
+            concatstring(d->obit, "was \fs");
             if(!actor[d->actortype].living) concatstring(d->obit, obitdestroyed);
             else if(!obitverbose) concatstring(d->obit, obitfragged);
             else if(burning) concatstring(d->obit, obitburn);
@@ -1532,7 +1534,7 @@ namespace game
                 else concatstring(d->obit, WF(WK(flags), weap, obituary, WS(flags)));
             }
             else concatstring(d->obit, obitkilled);
-            concatstring(d->obit, " by");
+            concatstring(d->obit, "\fS by");
             bool override = false;
             if(d->headless)
             {


### PR DESCRIPTION
This is a trivial addition that fixes a probable oversight I discovered while playing on an open vars server, that the obit vars are inserted directly into the message.
This addition uses the formatting code stack to prevent obituaries with such codes (`"^frshot"`, `"^fzvbzapped"`, etc) from leaking into the rest of the obituary line.
The workaround is just adding the stack codes or `^fw` into the obit var itself, but I think this is cleaner and makes things a little simpler for modders.