### PR TITLE
Only allow whispers directly toward bots to affect them.

### DIFF
--- a/src/game/ai.cpp
+++ b/src/game/ai.cpp
@@ -1824,7 +1824,9 @@ namespace ai
                 }
             }
             else aimed = true;
-            if(!m_edit(game::gamemode) && d->team != e->team && (!aimed || !client::haspriv(d, botoverridelock)))
+            if(aimed && t != e)
+                continue;
+            else if(!m_edit(game::gamemode) && d->team != e->team && (!aimed || !client::haspriv(d, botoverridelock)))
             {
                 if(aimed) botsay(e, d, "sorry, can't obey you");
                 continue;


### PR DESCRIPTION
This fixes the issue where if you send a message to any actor, all actors on that host (both the human and his bots) will receive the whisper. The result is several bot whispers in reply if you want to contact the human or a single bot, this pull request has bots ignore whispers that are not aimed directly at them.