### PR TITLE
Display all chat lines in demo playback regardless of target.

### DIFF
--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -1337,7 +1337,7 @@ namespace client
             int ret = execute(act);
             if(ret > 0) snd = ret;
         }
-        if((!(flags&SAY_TEAM) || f->team == game::player1->team) && (!(flags&SAY_WHISPER) || f == game::player1 || t == game::player1))
+        if(m_demo(game::gamemode) || ((!(flags&SAY_TEAM) || f->team == game::player1->team) && (!(flags&SAY_WHISPER) || f == game::player1 || t == game::player1)))
         {
             conoutft(CON_MESG, "%s", line);
             if(snd >= 0 && !issound(f->cschan)) playsound(snd, f->o, f, snd != S_CHAT ? 0 : SND_DIRECT, -1, -1, -1, &f->cschan);


### PR DESCRIPTION
This will aid in chat moderation, as previously whispers and team messages were not viewable even though they were recorded in the demo.