### PR TITLE
Making it possible to build server and genkey without SDL (when using CMake)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,10 @@ find_package(PkgConfig REQUIRED)
 set(common_deps zlib)
 set(client_deps sdl2 SDL2_image SDL2_mixer gl)
 # will be set to false if the client dependencies are not installed
-set(build_client true)
+set(BUILD_CLIENT true CACHE BOOL "Build client?")
+if(NOT ${BUILD_CLIENT})
+    message(STATUS "Will not build client as requested")
+endif()
 
 # the client depends on almost all the source files
 file(GLOB client_sources engine/*.cpp game/*.cpp shared/*.cpp support/sqlite3.c)
@@ -79,27 +82,30 @@ else()
 endif()
 
 # configure dependencies with pkg-config
-foreach(dep IN LISTS client_deps)
-    pkg_check_modules(${dep} ${dep})
-    if(NOT ${dep}_FOUND)
-        set(build_client false)
-    endif()
+if(${BUILD_CLIENT})
+    foreach(dep IN LISTS client_deps)
+        pkg_check_modules(${dep} ${dep})
+        if(NOT ${dep}_FOUND)
+            message(FATAL_ERROR "Could not find required packages for the client. You can run cmake with -DBUILD_CLIENT=0 to exclude the client.")
+        endif()
 
-    # add the necessary includes
-    foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
-        include_directories(${include_dir})
-    endforeach(include_dir)
+        # add the necessary includes
+        foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
+            include_directories(${include_dir})
+        endforeach(include_dir)
 
-    # link to the libraries
-    foreach(lib IN LISTS ${dep}_LIBRARIES)
-        link_libraries(${lib})
-    endforeach(lib)
+        # link to the libraries
+        foreach(lib IN LISTS ${dep}_LIBRARIES)
+            link_libraries(${lib})
+        endforeach(lib)
 
-    # tell the compiler where to find the libraries' binaries
-    foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
-        link_directories(${lib_dir})
-    endforeach(lib_dir)
-endforeach(dep)
+        # tell the compiler where to find the libraries' binaries
+        foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
+            link_directories(${lib_dir})
+        endforeach(lib_dir)
+    endforeach(dep)
+endif()
+
 foreach(dep IN LISTS common_deps)
     pkg_check_modules(${dep} REQUIRED ${dep})
 
@@ -119,10 +125,6 @@ foreach(dep IN LISTS common_deps)
     endforeach(lib_dir)
 endforeach(dep)
 
-if(NOT ${build_client})
-    message(WARNING "Will not build client because some dependencies were not found.")
-endif()
-
 # configure enet
 set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
 add_subdirectory(${ENET_SOURCE_DIRECTORY})
@@ -141,7 +143,7 @@ if(MINGW)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 endif()
 
-if(${build_client})
+if(${BUILD_CLIENT})
     # add the client executable and link it to enet
     add_executable(redeclipse${BIN_SUFFIX} ${client_sources})
     target_link_libraries(redeclipse${BIN_SUFFIX} enet)
@@ -158,7 +160,7 @@ set_target_properties(redeclipse_server${BIN_SUFFIX} PROPERTIES
 if(APPLE)
     # include framework required in xcode/ code
     find_library(COCOA_LIBRARY Cocoa)
-    if(${build_client})
+    if(${BUILD_CLIENT})
         target_link_libraries(redeclipse${BIN_SUFFIX} ${COCOA_LIBRARY})
     endif()
     target_link_libraries(redeclipse_server${BIN_SUFFIX} ${COCOA_LIBRARY})
@@ -180,7 +182,7 @@ else()
 endif()
 
 set(targets redeclipse_server${BIN_SUFFIX} genkey${BIN_SUFFIX})
-if(${build_client})
+if(${BUILD_CLIENT})
     set(targets redeclipse${BIN_SUFFIX} ${targets})
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(PkgConfig REQUIRED)
 # the dependencies required by all platforms
 set(common_deps zlib)
 set(client_deps sdl2 SDL2_image SDL2_mixer gl)
-# will be set to false if the client dependencies are not installed
+
 set(BUILD_CLIENT true CACHE BOOL "Build client?")
 if(NOT ${BUILD_CLIENT})
     message(STATUS "Will not build client as requested")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -ffast-math -fno-exc
 find_package(PkgConfig REQUIRED)
 # the dependencies required by all platforms
 set(client_deps zlib sdl2 SDL2_image SDL2_mixer gl)
+# will be set to false if the client dependencies are not installed
+set(build_client true)
 
 # the client depends on almost all the source files
 file(GLOB client_sources engine/*.cpp game/*.cpp shared/*.cpp support/sqlite3.c)
@@ -77,7 +79,10 @@ endif()
 
 # configure dependencies with pkg-config
 foreach(dep IN LISTS client_deps)
-    pkg_check_modules(${dep} REQUIRED ${dep})
+    pkg_check_modules(${dep} ${dep})
+    if(NOT ${dep}_${FOUND} OR NOT ${build_client})
+        set(build_client false)
+    endif()
 
     # add the necessary includes
     foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
@@ -94,6 +99,10 @@ foreach(dep IN LISTS client_deps)
         link_directories(${lib_dir})
     endforeach(lib_dir)
 endforeach(dep)
+
+if(NOT ${build_client})
+    message(WARNING "Will not build client because some dependencies were not found.")
+endif()
 
 # configure enet
 set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
@@ -113,9 +122,11 @@ if(MINGW)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 endif()
 
-# add the client executable and link it to enet
-add_executable(redeclipse${BIN_SUFFIX} ${client_sources})
-target_link_libraries(redeclipse${BIN_SUFFIX} enet)
+if(${build_client})
+    # add the client executable and link it to enet
+    add_executable(redeclipse${BIN_SUFFIX} ${client_sources})
+    target_link_libraries(redeclipse${BIN_SUFFIX} enet)
+endif()
 
 # add the server executable and link it to enet
 # (define STANDALONE to "notify" the preprocessor that the server is built this time)
@@ -128,7 +139,9 @@ set_target_properties(redeclipse_server${BIN_SUFFIX} PROPERTIES
 if(APPLE)
     # include framework required in xcode/ code
     find_library(COCOA_LIBRARY Cocoa)
-    target_link_libraries(redeclipse${BIN_SUFFIX} ${COCOA_LIBRARY})
+    if(${build_client})
+        target_link_libraries(redeclipse${BIN_SUFFIX} ${COCOA_LIBRARY})
+    endif()
     target_link_libraries(redeclipse_server${BIN_SUFFIX} ${COCOA_LIBRARY})
 else(APPLE)
     # add the genkey executable
@@ -143,7 +156,12 @@ elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x86_64")
 else()
     set(ARCHITECTURE "native")
 endif()
-set(targets redeclipse${BIN_SUFFIX} redeclipse_server${BIN_SUFFIX} genkey${BIN_SUFFIX})
+
+set(targets redeclipse_server${BIN_SUFFIX} genkey${BIN_SUFFIX})
+if(${build_client})
+    set(targets redeclipse${BIN_SUFFIX} ${targets})
+endif()
+
 foreach(target IN LISTS targets)
     install(
         TARGETS ${target}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -ffast-math -fno-exc
 # Use pkg-config to configure dependencies later
 find_package(PkgConfig REQUIRED)
 # the dependencies required by all platforms
-set(client_deps zlib sdl2 SDL2_image SDL2_mixer gl)
+set(common_deps zlib)
+set(client_deps sdl2 SDL2_image SDL2_mixer gl)
 # will be set to false if the client dependencies are not installed
 set(build_client true)
 
@@ -83,6 +84,24 @@ foreach(dep IN LISTS client_deps)
     if(NOT ${dep}_${FOUND} OR NOT ${build_client})
         set(build_client false)
     endif()
+
+    # add the necessary includes
+    foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
+        include_directories(${include_dir})
+    endforeach(include_dir)
+
+    # link to the libraries
+    foreach(lib IN LISTS ${dep}_LIBRARIES)
+        link_libraries(${lib})
+    endforeach(lib)
+
+    # tell the compiler where to find the libraries' binaries
+    foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
+        link_directories(${lib_dir})
+    endforeach(lib_dir)
+endforeach(dep)
+foreach(dep IN LISTS common_deps)
+    pkg_check_modules(${dep} REQUIRED ${dep})
 
     # add the necessary includes
     foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,39 @@
 cmake_minimum_required(VERSION 2.8.11)
 
+# configure_deps(TARGET <target> [FATAL] DEPS <deps>...)
+# Configures dependencies for <target>. <deps> is a list of dependencies.
+# If FATAL is specified then it exits on failure. Otherwise it returns
+# and sets configure_deps_failed.
+function(configure_deps)
+    cmake_parse_arguments(configure_deps "FATAL" "TARGET" "DEPS" "${ARGN}")
+    foreach(dep IN LISTS configure_deps_DEPS)
+        if(${configure_deps_FATAL})
+            pkg_check_modules(${dep} REQUIRED ${dep})
+        else()
+            pkg_check_modules(${dep} ${dep})
+        endif()
+        if(NOT ${dep}_FOUND)
+            set(configure_deps_failed true PARENT_SCOPE)
+            return()
+        endif()
+
+        # add the necessary includes
+        foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
+            include_directories(${include_dir})
+        endforeach(include_dir)
+
+        # link to the libraries
+        foreach(lib IN LISTS ${dep}_LIBRARIES)
+            target_link_libraries(${configure_deps_TARGET} ${lib})
+        endforeach(lib)
+
+        # tell the compiler where to find the libraries' binaries
+        foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
+            link_directories(${lib_dir})
+        endforeach(lib_dir)
+    endforeach(dep)
+endfunction(configure_deps)
+
 # set default build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (release or debug)" FORCE)
@@ -13,8 +47,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -ffast-math -fno-exc
 # Use pkg-config to configure dependencies later
 find_package(PkgConfig REQUIRED)
 # the dependencies required by all platforms
-set(common_deps zlib)
-set(client_deps sdl2 SDL2_image SDL2_mixer gl)
+set(client_deps zlib sdl2 SDL2_image SDL2_mixer gl)
+set(server_deps zlib)
+set(genkey_deps zlib)
 
 set(BUILD_CLIENT true CACHE BOOL "Build client?")
 if(NOT ${BUILD_CLIENT})
@@ -81,68 +116,6 @@ else()
     set(BIN_SUFFIX "_native")
 endif()
 
-# configure dependencies with pkg-config
-if(${BUILD_CLIENT})
-    foreach(dep IN LISTS client_deps)
-        pkg_check_modules(${dep} ${dep})
-        if(NOT ${dep}_FOUND)
-            message(FATAL_ERROR "Could not find required packages for the client. You can run cmake with -DBUILD_CLIENT=0 to exclude the client.")
-        endif()
-
-        # add the necessary includes
-        foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
-            include_directories(${include_dir})
-        endforeach(include_dir)
-
-        # link to the libraries
-        foreach(lib IN LISTS ${dep}_LIBRARIES)
-            link_libraries(${lib})
-        endforeach(lib)
-
-        # tell the compiler where to find the libraries' binaries
-        foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
-            link_directories(${lib_dir})
-        endforeach(lib_dir)
-    endforeach(dep)
-endif()
-
-foreach(dep IN LISTS common_deps)
-    pkg_check_modules(${dep} REQUIRED ${dep})
-
-    # add the necessary includes
-    foreach(include_dir IN LISTS ${dep}_INCLUDE_DIRS)
-        include_directories(${include_dir})
-    endforeach(include_dir)
-
-    # link to the libraries
-    foreach(lib IN LISTS ${dep}_LIBRARIES)
-        link_libraries(${lib})
-    endforeach(lib)
-
-    # tell the compiler where to find the libraries' binaries
-    foreach(lib_dir IN LISTS ${dep}_LIBRARY_DIRS)
-        link_directories(${lib_dir})
-    endforeach(lib_dir)
-endforeach(dep)
-
-# configure enet
-set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
-add_subdirectory(${ENET_SOURCE_DIRECTORY})
-
-# configure local includes
-include_directories(
-    ${ENET_SOURCE_DIRECTORY}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/engine
-    ${CMAKE_CURRENT_SOURCE_DIR}/game
-    ${CMAKE_CURRENT_SOURCE_DIR}/shared
-    ${CMAKE_CURRENT_SOURCE_DIR}/support
-)
-
-# include the headers for the libraries bundled in ../bin
-if(MINGW)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-endif()
-
 if(${BUILD_CLIENT})
     # add the client executable and link it to enet
     add_executable(redeclipse${BIN_SUFFIX} ${client_sources})
@@ -171,6 +144,34 @@ else(APPLE)
         COMPILE_FLAGS "-DSTANDALONE"
     )
 endif(APPLE)
+
+# configure dependencies
+if(${BUILD_CLIENT})
+    configure_deps(TARGET redeclipse${BIN_SUFFIX} DEPS ${client_deps})
+    if(configure_deps_failed)
+        message(FATAL_ERROR "Could not find required packages for the client. You can run cmake with -DBUILD_CLIENT=0 to exclude the client.")
+    endif()
+endif()
+configure_deps(TARGET redeclipse_server${BIN_SUFFIX} FATAL DEPS ${server_deps})
+configure_deps(TARGET genkey${BIN_SUFFIX} FATAL DEPS ${genkey_deps})
+
+# configure enet
+set(ENET_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/enet)
+add_subdirectory(${ENET_SOURCE_DIRECTORY})
+
+# configure local includes
+include_directories(
+    ${ENET_SOURCE_DIRECTORY}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/engine
+    ${CMAKE_CURRENT_SOURCE_DIR}/game
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared
+    ${CMAKE_CURRENT_SOURCE_DIR}/support
+)
+
+# include the headers for the libraries bundled in ../bin
+if(MINGW)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif()
 
 # install to ../bin/
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "i[3-6]86")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 # configure dependencies with pkg-config
 foreach(dep IN LISTS client_deps)
     pkg_check_modules(${dep} ${dep})
-    if(NOT ${dep}_${FOUND} OR NOT ${build_client})
+    if(NOT ${dep}_FOUND)
         set(build_client false)
     endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,9 @@ if(APPLE)
 else(APPLE)
     # add the genkey executable
     add_executable(genkey${BIN_SUFFIX} ${genkey_sources})
+    set_target_properties(genkey${BIN_SUFFIX} PROPERTIES
+        COMPILE_FLAGS "-DSTANDALONE"
+    )
 endif(APPLE)
 
 # install to ../bin/


### PR DESCRIPTION
I tried to compile the Red Eclipse server on a server that did not have SDL installed but that failed because SDL is a required dependency for all targets in CMakeLists.txt.

This pull request makes SDL optional, and if it is not found then the client will not be compiled but the server and genkey will still be.