### PR TITLE
Show users what version they need when loading demos and maps

### DIFF
--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -1270,7 +1270,7 @@ bool load_world(const char *mname, int crc)       // still supports all map form
             #undef MAPZCOMPAT
             if(newhdr.version > MAPVERSION)
             {
-                conoutf("\frError loading %s: requires a newer version of %s", mapname, versionname);
+                conoutf("\frError loading %s: requires a newer version of %s (with map format version %d)", mapname, versionname, newhdr.version);
                 delete f;
                 maskpackagedirs(mask);
                 return false;
@@ -1466,7 +1466,7 @@ bool load_world(const char *mname, int crc)       // still supports all map form
             #undef OCTAVARS
             if(ohdr.version > OCTAVERSION)
             {
-                conoutf("\frError loading %s: requires a newer version of Cube 2 support", mapname);
+                conoutf("\frError loading %s: requires a newer version of Cube 2 support (version %d)", mapname, ohdr.version);
                 delete f;
                 maskpackagedirs(mask);
                 return false;
@@ -2083,7 +2083,7 @@ int scanmapc(const char *fname)
             #undef MAPZCOMPAT
             if(d.maphdr.version > MAPVERSION)
             {
-                formatstring(msg, "Error loading %s: requires a newer version of %s", d.fileext, versionname);
+                formatstring(msg, "Error loading %s: requires a newer version of %s (with map format version %d)", d.fileext, versionname, d.maphdr.version);
                 delete f;
                 maskpackagedirs(mask);
                 mapcinfos.pop();
@@ -2245,7 +2245,7 @@ int scanmapc(const char *fname)
             #undef OCTACOMPAT
             if(ohdr.version > OCTAVERSION)
             {
-                formatstring(msg, "\frError loading %s: requires a newer version of Cube 2 support", d.fileext);
+                formatstring(msg, "\frError loading %s: requires a newer version of Cube 2 support (version %d)", d.fileext, ohdr.version);
                 delete f;
                 maploading = 0;
                 maskpackagedirs(mask);

--- a/src/game/client.cpp
+++ b/src/game/client.cpp
@@ -227,7 +227,7 @@ namespace client
         {
             lilswap(&d.hdr.gamever, 4);
             if(d.hdr.gamever!=VERSION_GAME)
-                formatstring(msg, "\frDemo \fs\fc%s\fS requires \fs\fc%s\fS version of %s", name, d.hdr.gamever<VERSION_GAME ? "an older" : "a newer", VERSION_NAME);
+                formatstring(msg, "\frDemo \fs\fc%s\fS requires \fs\fc%s\fS version of %s (with protocol version %d)", name, d.hdr.gamever<VERSION_GAME ? "an older" : "a newer", VERSION_NAME, d.hdr.gamever);
         }
         delete f;
         if(msg[0])

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -2375,7 +2375,7 @@ namespace server
         {
             lilswap(&hdr.gamever, 4);
             if(hdr.gamever!=VERSION_GAME)
-                formatstring(msg, "\frDemo \fs\fc%s\fS requires %s version of %s", file, hdr.gamever<VERSION_GAME ? "an older" : "a newer", versionname);
+                formatstring(msg, "\frDemo \fs\fc%s\fS requires %s version of %s (with protocol version %d)", file, hdr.gamever<VERSION_GAME ? "an older" : "a newer", versionname, hdr.gamever);
         }
         if(msg[0])
         {


### PR DESCRIPTION
I tried to load a demo but it told me that I needed an older version. I tried an older version but I still needed an older version... This change makes it possible to get the correct version without having to try different versions when loading demos and maps.