### PR TITLE
Fix alt-tab disconnecting the client from servers on some Linux systems

### DIFF
--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -673,9 +673,11 @@ void processkey(int code, bool isdown)
         case SDLK_RETURN:
             keyintercept(fullscreen, setfullscreen(!(SDL_GetWindowFlags(screen) & SDL_WINDOW_FULLSCREEN)));
             break;
+#if defined(WIN32) || defined(__APPLE__)
         case SDLK_TAB:
             keyintercept(iconify, SDL_MinimizeWindow(screen));
             break;
+#endif
         case SDLK_CAPSLOCK:
             if(!isdown) capslockon = capslocked();
             break;

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -1061,9 +1061,6 @@ int main(int argc, char **argv)
     setcaption("Loading, please wait..");
     SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "0");
     SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "0");
-    #if !defined(WIN32) && !defined(__APPLE__)
-    SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
-    #endif
     setupscreen();
     SDL_ShowCursor(SDL_FALSE);
     SDL_StopTextInput(); // workaround for spurious text-input events getting sent on first text input toggle?


### PR DESCRIPTION
See issue #700, fix provided by @pocak100

Tested on KDE Neon and Windows 10, works as intended on both.

