### PR TITLE
Make oldschool duel/survivor count frags for points instead of rounds won.

### DIFF
--- a/src/game/duelmut.h
+++ b/src/game/duelmut.h
@@ -383,10 +383,10 @@ struct duelservmode : servmode
                                         {
                                             if(!m_affinity(gamemode))
                                             {
-                                                givepoints(clients[i], 1, true, teampoints);
+                                                givepoints(clients[i], 1, !m_dm_oldschool(gamemode, mutators), teampoints);
                                                 teampoints = false;
                                             }
-                                            else if(!duelaffin && teampoints)
+                                            else if(!duelaffin && teampoints && !m_dm_oldschool(gamemode, mutators))
                                             {
                                                 score &ts = teamscore(clients[i]->team);
                                                 ts.total++;
@@ -461,12 +461,15 @@ struct duelservmode : servmode
                                     if(clients[i] == alive[0])
                                     {
                                         ancmsgft(clients[i]->clientnum, S_V_YOUWIN, CON_EVENT, "%s", end);
-                                        if(!m_affinity(gamemode)) givepoints(clients[i], 1, true, true);
-                                        else if(!duelaffin)
+                                        if(!m_dm_oldschool(gamemode, mutators))
                                         {
-                                            score &ts = teamscore(clients[i]->team);
-                                            ts.total++;
-                                            sendf(-1, 1, "ri3", N_SCORE, ts.team, ts.total);
+                                            if(!m_affinity(gamemode)) givepoints(clients[i], 1, true, true);
+                                            else if(!duelaffin)
+                                            {
+                                                score &ts = teamscore(clients[i]->team);
+                                                ts.total++;
+                                                sendf(-1, 1, "ri3", N_SCORE, ts.team, ts.total);
+                                            }
                                         }
                                     }
                                     else ancmsgft(clients[i]->clientnum, S_V_YOULOSE, CON_EVENT, "%s", end);

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -4354,9 +4354,9 @@ namespace server
                 if(v != m && v->actortype >= A_ENEMY && m->actortype < A_ENEMY)
                 {
                     pointvalue = -pointvalue;
-                    givepoints(m, pointvalue, m_points(gamemode, mutators), true);
+                    givepoints(m, pointvalue, m_points(gamemode, mutators) || m_dm_oldschool(gamemode, mutators), true);
                 }
-                else if(v->actortype < A_ENEMY) givepoints(v, pointvalue, m_points(gamemode, mutators), true);
+                else if(v->actortype < A_ENEMY) givepoints(v, pointvalue, m_points(gamemode, mutators) || m_dm_oldschool(gamemode, mutators), true);
             }
             m->deaths++;
             m->totaldeaths++;
@@ -4440,7 +4440,7 @@ namespace server
                 pointvalue = (smode ? smode->points(ci, ci) : -1)*G(fragbonus);
                 if(kamikaze) pointvalue *= G(teamkillpenalty);
             }
-            givepoints(ci, pointvalue, m_points(gamemode, mutators), true);
+            givepoints(ci, pointvalue, m_points(gamemode, mutators) || m_dm_oldschool(gamemode, mutators), true);
         }
         if(G(burntime) && flags&HIT_BURN)
         {


### PR DESCRIPTION
I've seen this suggested several times before, it gives oldschool + duel/survivor a bit of a twist where you must try to frag as many players as possible before dying rather than only trying to survive.