### PR TITLE
Clean up database. Improve players, weapons and servers schema.

### DIFF
--- a/sql/stats/create.sql
+++ b/sql/stats/create.sql
@@ -14,14 +14,17 @@ CREATE TABLE games (
 );
 
 CREATE TABLE game_servers (
-    game INTEGER,
-    handle TEXT,
-    flags TEXT,
-    desc TEXT,
-    version TEXT,
-    host TEXT,
-    port INTEGER
+    game INTEGER PRIMARY KEY,
+    handle TEXT NOT NULL,
+    flags TEXT NOT NULL,
+    desc TEXT NOT NULL,
+    version TEXT NOT NULL,
+    host TEXT NOT NULL,
+    port INTEGER NOT NULL,
+    CHECK (handle <> ''),
+    FOREIGN KEY (game) REFERENCES games(id)
 );
+CREATE INDEX game_servers_handle ON game_servers(handle);
 
 CREATE TABLE game_teams (
     game INTEGER,
@@ -31,40 +34,56 @@ CREATE TABLE game_teams (
 );
 
 CREATE TABLE game_players (
-    game INTEGER,
-    name TEXT,
+    game INTEGER NOT NULL,
+    name TEXT NOT NULL,
     handle TEXT,
-    score INTEGER,
-    timealive INTEGER,
-    frags INTEGER,
-    deaths INTEGER,
-    wid INTEGER,
-    timeactive INTEGER
+    score INTEGER NOT NULL,
+    timealive INTEGER NOT NULL,
+    timeactive INTEGER NOT NULL,
+    frags INTEGER NOT NULL,
+    deaths INTEGER NOT NULL,
+    wid INTEGER NOT NULL,
+    CHECK (name <> ''),
+    CHECK (handle <> ''),
+    UNIQUE (game, wid),
+    UNIQUE (game, handle), -- nulls are distinct from each other
+    FOREIGN KEY (game) REFERENCES games(id)
 );
+CREATE INDEX game_players_game ON game_players(game);
+CREATE INDEX game_players_handle ON game_players(handle);
 
 CREATE TABLE game_weapons (
-    game INTEGER,
-    player INTEGER,
+    game INTEGER NOT NULL,
+    player INTEGER NOT NULL,
     playerhandle TEXT,
-    weapon TEXT,
+    weapon TEXT NOT NULL,
 
-    timewielded INTEGER,
-    timeloadout INTEGER,
+    timewielded INTEGER NOT NULL,
+    timeloadout INTEGER NOT NULL,
 
-    damage1 INTEGER,
-    frags1 INTEGER,
-    hits1 INTEGER,
-    flakhits1 INTEGER,
-    shots1 INTEGER,
-    flakshots1 INTEGER,
+    damage1 INTEGER NOT NULL,
+    frags1 INTEGER NOT NULL,
+    hits1 INTEGER NOT NULL,
+    flakhits1 INTEGER NOT NULL,
+    shots1 INTEGER NOT NULL,
+    flakshots1 INTEGER NOT NULL,
 
-    damage2 INTEGER,
-    frags2 INTEGER,
-    hits2 INTEGER,
-    flakhits2 INTEGER,
-    shots2 INTEGER,
-    flakshots2 INTEGER
+    damage2 INTEGER NOT NULL,
+    frags2 INTEGER NOT NULL,
+    hits2 INTEGER NOT NULL,
+    flakhits2 INTEGER NOT NULL,
+    shots2 INTEGER NOT NULL,
+    flakshots2 INTEGER NOT NULL,
+
+    CHECK (timewielded > 0 OR timeloadout > 0),
+    CHECK (playerhandle <> ''),
+    CHECK (weapon IN ('melee', 'pistol', 'sword', 'shotgun', 'smg', 'flamer', 'plasma', 'zapper', 'rifle', 'grenade', 'mine', 'rocket', 'claw')),
+    FOREIGN KEY (game) REFERENCES games(id)
+    FOREIGN KEY (game, player) REFERENCES game_players(game, wid)
 );
+CREATE INDEX game_weapons_game ON game_weapons(game);
+CREATE INDEX game_weapons_playerhandle ON game_weapons(playerhandle);
+CREATE INDEX game_weapons_weapon ON game_weapons(weapon);
 
 CREATE TABLE game_ffarounds (
     game INTEGER,

--- a/sql/stats/upgrade_5.sql
+++ b/sql/stats/upgrade_5.sql
@@ -1,0 +1,123 @@
+BEGIN EXCLUSIVE;
+
+-- game weapons
+
+DELETE FROM game_weapons WHERE
+  weapon NOT IN ('melee', 'pistol', 'sword', 'shotgun', 'smg', 'flamer', 'plasma', 'zapper', 'rifle', 'grenade', 'mine', 'rocket', 'claw')
+  OR timewielded = 0 AND timeloadout = 0
+  OR game NOT IN (SELECT id FROM games);
+
+UPDATE game_weapons SET playerhandle = NULL WHERE playerhandle = '';
+
+ALTER TABLE game_weapons RENAME TO gw_old;
+
+CREATE TABLE game_weapons (
+    game INTEGER NOT NULL,
+    player INTEGER NOT NULL,
+    playerhandle TEXT,
+    weapon TEXT NOT NULL,
+
+    timewielded INTEGER NOT NULL,
+    timeloadout INTEGER NOT NULL,
+
+    damage1 INTEGER NOT NULL,
+    frags1 INTEGER NOT NULL,
+    hits1 INTEGER NOT NULL,
+    flakhits1 INTEGER NOT NULL,
+    shots1 INTEGER NOT NULL,
+    flakshots1 INTEGER NOT NULL,
+
+    damage2 INTEGER NOT NULL,
+    frags2 INTEGER NOT NULL,
+    hits2 INTEGER NOT NULL,
+    flakhits2 INTEGER NOT NULL,
+    shots2 INTEGER NOT NULL,
+    flakshots2 INTEGER NOT NULL,
+
+    CHECK (timewielded > 0 OR timeloadout > 0),
+    CHECK (playerhandle <> ''),
+    CHECK (weapon IN ('melee', 'pistol', 'sword', 'shotgun', 'smg', 'flamer', 'plasma', 'zapper', 'rifle', 'grenade', 'mine', 'rocket', 'claw')),
+    FOREIGN KEY (game) REFERENCES games(id)
+    FOREIGN KEY (game, player) REFERENCES game_players(game, wid)
+);
+
+CREATE INDEX game_weapons_game ON game_weapons(game);
+CREATE INDEX game_weapons_playerhandle ON game_weapons(playerhandle);
+CREATE INDEX game_weapons_weapon ON game_weapons(weapon);
+
+INSERT OR ROLLBACK INTO game_weapons (game, player, playerhandle, weapon, timewielded, timeloadout, damage1, frags1, hits1, flakhits1, shots1, flakshots1, damage2, frags2, hits2, flakhits2, shots2, flakshots2)
+SELECT game, player, playerhandle, weapon, timewielded, timeloadout, damage1, frags1, hits1, flakhits1, shots1, flakshots1, damage2, frags2, hits2, flakhits2, shots2, flakshots2
+FROM gw_old;
+
+DROP TABLE gw_old;
+
+-- game players
+
+DELETE FROM game_players WHERE timealive = 0 AND timeactive = 0 OR name = '' OR name IS NULL;
+DELETE FROM games WHERE id IN (SELECT game FROM game_players GROUP BY game, wid HAVING COUNT(*) > 1);
+DELETE FROM game_players WHERE game NOT IN (SELECT id FROM games);
+DELETE FROM game_weapons WHERE game NOT IN (SELECT id FROM games);
+DELETE FROM game_weapons WHERE ROWID IN (SELECT gw.ROWID from game_weapons as gw left join game_players as gp on gp.game=gw.game and gp.wid=gw.player WHERE name IS NULL);
+
+UPDATE game_players SET handle = NULL WHERE handle = '';
+
+ALTER TABLE game_players RENAME TO gp_old;
+
+CREATE TABLE game_players (
+  game INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  handle TEXT,
+  score INTEGER NOT NULL,
+  timealive INTEGER NOT NULL,
+  timeactive INTEGER NOT NULL,
+  frags INTEGER NOT NULL,
+  deaths INTEGER NOT NULL,
+  wid INTEGER NOT NULL,
+  CHECK (name <> ''),
+  CHECK (handle <> ''),
+  UNIQUE (game, wid),
+  UNIQUE (game, handle), -- nulls are distinct from each other
+  FOREIGN KEY (game) REFERENCES games(id)
+);
+CREATE INDEX game_players_game ON game_players(game);
+CREATE INDEX game_players_handle ON game_players(handle);
+
+INSERT OR ROLLBACK INTO game_players (game, name, handle, score, timealive, timeactive, frags, deaths, wid)
+SELECT gpo.game, gpo.name, gpo.handle, gpo.score, gpo.timealive, gpo.timeactive, gpo.frags, gpo.deaths, gpo.wid
+FROM gp_old AS gpo
+JOIN (SELECT DISTINCT game AS gw_game, player AS gw_wid FROM game_weapons) ON gw_game = gpo.game AND gw_wid = gpo.wid;
+
+DROP TABLE gp_old;
+
+-- game servers
+
+DELETE FROM game_servers WHERE handle = '' OR handle IS NULL;
+DELETE FROM games WHERE id NOT IN (SELECT game FROM game_servers);
+DELETE FROM game_servers WHERE game NOT IN (SELECT id FROM games);
+DELETE FROM game_weapons WHERE game NOT IN (SELECT id FROM games);
+DELETE FROM game_players WHERE game NOT IN (SELECT id FROM games);
+
+ALTER TABLE game_servers RENAME TO gs_old;
+
+CREATE TABLE game_servers (
+  game INTEGER PRIMARY KEY,
+  handle TEXT NOT NULL,
+  flags TEXT NOT NULL,
+  desc TEXT NOT NULL,
+  version TEXT NOT NULL,
+  host TEXT NOT NULL,
+  port INTEGER NOT NULL,
+  CHECK (handle <> ''),
+  FOREIGN KEY (game) REFERENCES games(id)
+);
+CREATE INDEX game_servers_handle ON game_servers(handle);
+
+INSERT OR ROLLBACK INTO game_servers (game, handle, flags, desc, version, host, port)
+SELECT game, handle, flags, desc, version, host, port
+FROM gs_old;
+
+DROP TABLE gs_old;
+
+DELETE FROM games WHERE id IN (SELECT g.id from games as g left join game_players as gp on g.id=gp.game WHERE name IS NULL);
+
+COMMIT;

--- a/sql/stats/upgrade_5.sql
+++ b/sql/stats/upgrade_5.sql
@@ -1,5 +1,3 @@
-BEGIN EXCLUSIVE;
-
 -- game weapons
 
 DELETE FROM game_weapons WHERE
@@ -119,5 +117,3 @@ FROM gs_old;
 DROP TABLE gs_old;
 
 DELETE FROM games WHERE id IN (SELECT g.id from games as g left join game_players as gp on g.id=gp.game WHERE name IS NULL);
-
-COMMIT;

--- a/src/engine/master.cpp
+++ b/src/engine/master.cpp
@@ -10,7 +10,7 @@
 #include <enet/time.h>
 #include <sqlite3.h>
 
-#define STATSDB_VERSION 5
+#define STATSDB_VERSION 6
 #define STATSDB_RETRYTIME (5*1000)
 #define MASTER_LIMIT 4096
 #define CLIENT_TIME (60*1000)
@@ -395,7 +395,7 @@ void savestats(masterclient &c)
     );
     c.stats.id = (ulong)sqlite3_last_insert_rowid(statsdb);
 
-    statsdbexecf("INSERT INTO game_servers VALUES (%d, %Q, %Q, %Q, %Q, %Q, %d)",
+    statsdbexecf("INSERT OR ROLLBACK INTO game_servers VALUES (%d, %Q, %Q, %Q, %Q, %Q, %d)",
         c.stats.id,
         c.authhandle,
         c.flags,
@@ -417,10 +417,10 @@ void savestats(masterclient &c)
 
     loopv(c.stats.players)
     {
-        statsdbexecf("INSERT INTO game_players VALUES (%d, %Q, %Q, %d, %d, %d, %d, %d, %d)",
+        statsdbexecf("INSERT OR ROLLBACK INTO game_players VALUES (%d, %Q, %Q, %d, %d, %d, %d, %d, %d)",
             c.stats.id,
             c.stats.players[i].name,
-            c.stats.players[i].handle,
+            c.stats.players[i].handle[0] ? c.stats.players[i].handle : NULL,
             c.stats.players[i].score,
             c.stats.players[i].timealive,
             c.stats.players[i].frags,
@@ -432,10 +432,10 @@ void savestats(masterclient &c)
 
     loopv(c.stats.weapstats)
     {
-        statsdbexecf("INSERT INTO game_weapons VALUES (%d, %d, %Q, %Q, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d)",
+        statsdbexecf("INSERT OR ROLLBACK INTO game_weapons VALUES (%d, %d, %Q, %Q, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d)",
             c.stats.id,
             c.stats.weapstats[i].playerid,
-            c.stats.weapstats[i].playerhandle,
+            c.stats.weapstats[i].playerhandle[0] ? c.stats.weapstats[i].playerhandle : NULL,
             c.stats.weapstats[i].name,
 
             c.stats.weapstats[i].timewielded,

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -3336,7 +3336,7 @@ namespace server
                 requestmasterf("stats team %d %d %s\n", i + tp, teamscore(i + tp).total, escapestring(TEAM(i + tp, name)));
                 flushmasteroutput();
             }
-            loopv(savedstatsscores) if(savedstatsscores[i].actortype == A_PLAYER)
+            loopv(savedstatsscores) if(savedstatsscores[i].actortype == A_PLAYER && (savedstatsscores[i].timealive > 0 || savedstatsscores[i].timeactive > 0))
             {
                 requestmasterf("stats player %s %s %d %d %d %d %d %d\n",
                     escapestring(savedstatsscores[i].name), escapestring(savedstatsscores[i].handle),
@@ -3348,6 +3348,7 @@ namespace server
                 loopj(W_MAX)
                 {
                     weaponstats w = savedstatsscores[i].weapstats[j];
+                    if (w.timewielded == 0 && w.timeloadout == 0) continue;
                     requestmasterf("stats weapon %d %s %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
                         i, escapestring(savedstatsscores[i].handle), weaptype[j].name, w.timewielded, w.timeloadout,
                         w.damage1, w.frags1, w.hits1, w.flakhits1, w.shots1, w.flakshots1,


### PR DESCRIPTION
Several updates to the stats db.

 * Removes invalid `game_weapons` and `game_weapons` that weren't used by a player (`timewielded=0 AND timeloadout=0`).
 * Removes `game_players` that weren't playing (`timeactive=0 AND timealive=0`).
 * Removes corrupted `games` that has several players with the same `game_players.wid`.
 * Removes data for non-existing games.
 * Add constraints to `game_servers`, `game_players` and `game_weapons` to improve database integrity, as currently there's a lot of invalid data.
 * Add table indices. This won't significantly improve `statsdb-interface` performance as there're other issues to it.