### PR TITLE
Do not begin burn residual when underwater.

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1246,7 +1246,7 @@ namespace game
 
     bool burn(gameent *d, int weap, int flags)
     {
-        if(wr_burns(weap, flags))
+        if(wr_burns(weap, flags) && (d->submerged < G(liquidextinguish) || (d->inmaterial&MATF_VOLUME) != MAT_WATER))
         {
             d->lastrestime[WR_BURN] = lastmillis;
             if(isweap(weap) || flags&HIT_MATERIAL) d->lastres[WR_BURN] = lastmillis;

--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -4199,7 +4199,7 @@ namespace server
                     }
                 }
                 if(m->health <= 0) realflags |= HIT_KILL;
-                if(wr_burning(weap, flags))
+                if(wr_burning(weap, flags) && (m->submerged < G(liquidextinguish) || (m->inmaterial&MATF_VOLUME) != MAT_WATER))
                 {
                     m->lastres[WR_BURN] = m->lastrestime[WR_BURN] = gamemillis;
                     m->lastresowner[WR_BURN] = v->clientnum;


### PR DESCRIPTION
Currently (in master and stable), getting hit by a burn-inducing weapon will cause burn status even when fully submerged, as the only check for liquid extinguishing is upon an `inmaterial` change. This pull request stops the burn status from occurring if the target is already submerged.