### PR TITLE
Use parentheses in macro

### DIFF
--- a/src/game/physics.cpp
+++ b/src/game/physics.cpp
@@ -1049,9 +1049,9 @@ namespace physics
         {
             #define mattrig(mo,mcol,ms,mt,mz,mq,mp,mw) \
             { \
-                int col = (int(mcol[2]*mq) + (int(mcol[1]*mq) << 8) + (int(mcol[0]*mq) << 16)); \
+                int col = (int(mcol[2]*(mq)) + (int(mcol[1]*(mq)) << 8) + (int(mcol[0]*(mq)) << 16)); \
                 regularshape(mp, mt, col, 21, 20, mz, mo, ms, 1, 10, 0, 20); \
-                if(mw >= 0) playsound(mw, mo, pl); \
+                if((mw) >= 0) playsound(mw, mo, pl);                    \
             }
             if(curmat == MAT_WATER || oldmat == MAT_WATER)
             {


### PR DESCRIPTION
I put parentheses in the macro mattrig so that things happen the expected way.

mattrig is called with a shorthand if statement in one place which messes up the `if (mw >= 0)` statement. gcc 7.1 also gives a warning about integer constants in boolean context.