### PR TITLE
Show message if deps not found in link_deps_dirs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,10 @@ endif()
 
 if(${BUILD_CLIENT})
     # set up library directories
-    link_deps_dirs(FATAL DEPS ${client_deps})
+    link_deps_dirs(DEPS ${client_deps})
+    if(link_deps_dirs_failed)
+        message(FATAL_ERROR "Could not find required packages for the client. You can run cmake with -DBUILD_CLIENT=0 to exclude the client.")
+    endif()
     # add the client executable and link it to enet
     add_executable(redeclipse${BIN_SUFFIX} ${client_sources})
     target_link_libraries(redeclipse${BIN_SUFFIX} enet)


### PR DESCRIPTION
When `link_deps_dirs` was added it was used with the FATAL flag so that cmake would die without showing a message about using `-DBUILD_CLIENT=0` if the dependencies were not found. This happens because `link_deps_dirs` is executed before `configure_deps`, where the `configure_deps_failed` check is. In this PR this check is now performed in both places (but it is technically not needed in the second one anymore, should we keep it or remove it?).