### PR TITLE
Add dashstyle 2: double tap when not falling

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -301,7 +301,7 @@ setdesc "impulsekick" "determines the minimum angle to switch between wall kick 
 setdesc "impulsemethod" "determines which impulse method to use, 0 = none, 1 = power jump, 2 = power slide, 3 = both" "value"
 setdesc "impulseaction" "determines how impulse action works, 0 = off, 1 = impulse jump, 2 = impulse dash, 3 = both" "value"
 setdesc "impulseroll" "determines the camera angle tilt when wallrunning" "angle"
-setdesc "dashstyle" "0 = only with impulse, 1 = double tap" "value"
+setdesc "dashstyle" "0 = only with impulse, 1 = double tap, 2 = double tap when not falling" "value"
 setdesc "crouchstyle" "0 = press and hold, 1 = double-tap toggle, 2 = toggle" "value"
 setdesc "walkstyle" "0 = press and hold, 1 = double-tap toggle, 2 = toggle" "value"
 setdesc "kickoffstyle" "client side option for wall jumps. 0 = fixed angle, 1 = direction of view" ""

--- a/src/game/physics.cpp
+++ b/src/game/physics.cpp
@@ -19,7 +19,7 @@ namespace physics
     FVAR(IDF_PERSIST, impulseroll, 0, 15, 89);
 
     VAR(IDF_PERSIST, jumpstyle, 0, 1, 1); // 0 = unpressed on action, 1 = remains pressed
-    VAR(IDF_PERSIST, dashstyle, 0, 1, 1); // 0 = only with impulse, 1 = double tap
+    VAR(IDF_PERSIST, dashstyle, 0, 1, 2); // 0 = only with impulse, 1 = double tap, 2 = double tap when not falling
     VAR(IDF_PERSIST, crouchstyle, 0, 0, 2); // 0 = press and hold, 1 = double-tap toggle, 2 = toggle
     VAR(IDF_PERSIST, walkstyle, 0, 0, 2); // 0 = press and hold, 1 = double-tap toggle, 2 = toggle
     VAR(IDF_PERSIST, grabstyle, 0, 2, 2); // 0 = up=up down=down, 1 = up=down down=up, 2 = up=up, down=up
@@ -65,7 +65,7 @@ namespace physics
             game::player1->v = dir; \
             if(down) \
             { \
-                if(allowimpulse(game::player1, A_A_DASH) && dashstyle && impulseaction&2 && last##v && lastdir##v && dir == lastdir##v && lastmillis-last##v < PHYSMILLIS) \
+                if(allowimpulse(game::player1, A_A_DASH) && dashstyle && (dashstyle == 1 || game::player1->physstate != PHYS_FALL) && impulseaction&2 && last##v && lastdir##v && dir == lastdir##v && lastmillis-last##v < PHYSMILLIS) \
                 { \
                     game::player1->action[AC_DASH] = true; \
                     game::player1->actiontime[AC_DASH] = lastmillis; \


### PR DESCRIPTION
This new dashstyle will allow double tap dashing only when the player is not in the falling state. It will give players who have a tendency to double tap while in the air the option to avoid unwanted dashes and also keep the ability to dash on the ground. They can still perform the same dash-in-air effect with the impulse move if this option is set.

This was requested by @JeffBobbo 