### PR TITLE
Collide less with occluded faces. Fixes #221.

### DIFF
--- a/src/engine/octa.h
+++ b/src/engine/octa.h
@@ -336,3 +336,4 @@ enum
     GENFACEVERTSXY(x0,x1, y0,y1, z0,z1, c0,c1, r0,r1, d0,d1) \
     GENFACEVERTSZ(x0,x1, y0,y1, z0,z1, c0,c1, r0,r1, d0,d1)
 
+bool collidesolidface(const cube &c, const int orient, const ivec &co, const int size);

--- a/src/engine/octa.h
+++ b/src/engine/octa.h
@@ -336,4 +336,4 @@ enum
     GENFACEVERTSXY(x0,x1, y0,y1, z0,z1, c0,c1, r0,r1, d0,d1) \
     GENFACEVERTSZ(x0,x1, y0,y1, z0,z1, c0,c1, r0,r1, d0,d1)
 
-bool collidesolidface(const cube &c, const int orient, const ivec &co, const int size);
+extern bool collidesolidface(const cube &c, const int orient, const ivec &co, const int size);

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -915,8 +915,10 @@ static bool fuzzycollidesolid(physent *d, const vec &dir, float cutoff, const cu
 
     collidewall = vec(0, 0, 0);
     float bestdist = -1e10f;
-    int visible = isentirelysolid(c) ? c.visible : 0xFF;
-    #define CHECKSIDE(side, distval, dotval, margin, normal) if(visible&(1<<side) && collidesolidface(c, side, co, size)) do \
+    int visible = isentirelysolid(c) ? c.visible : 0xFF, collide = 0;
+    loopi(6) if((visible>>i)&1) collide |=  collidesolidface(c, i, co, size) << i;
+    visible = collide;
+    #define CHECKSIDE(side, distval, dotval, margin, normal) if(visible&(1<<side)) do \
     { \
         float dist = distval; \
         if(dist > 0) return false; \
@@ -1036,7 +1038,9 @@ static bool cubecollidesolid(physent *d, const vec &dir, float cutoff, const cub
 
     collidewall = vec(0, 0, 0);
     float bestdist = -1e10f;
-    int visible = isentirelysolid(c) ? c.visible : 0xFF;
+    int visible = isentirelysolid(c) ? c.visible : 0xFF, collide = 0;
+    loopi(6) if((visible>>i)&1) collide |=  collidesolidface(c, i, co, size) << i;
+    visible = collide;
     CHECKSIDE(O_LEFT, co.x - entvol.right(), -dir.x, -d->radius, vec(-1, 0, 0));
     CHECKSIDE(O_RIGHT, entvol.left() - (co.x + size), dir.x, -d->radius, vec(1, 0, 0));
     CHECKSIDE(O_BACK, co.y - entvol.front(), -dir.y, -d->radius, vec(0, -1, 0));

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -915,9 +915,13 @@ static bool fuzzycollidesolid(physent *d, const vec &dir, float cutoff, const cu
 
     collidewall = vec(0, 0, 0);
     float bestdist = -1e10f;
-    int visible = isentirelysolid(c) ? c.visible : 0xFF, collide = 0;
-    loopi(6) if((visible>>i)&1) collide |=  collidesolidface(c, i, co, size) << i;
-    visible = collide;
+    int visible = isentirelysolid(c) ? c.visible : 0xFF;
+    if(d->type<ENT_CAMERA)
+    {
+        int collide = 0;
+        loopi(6) if((visible>>i)&1) collide |= collidesolidface(c, i, co, size) << i;
+        visible = collide;
+    }
     #define CHECKSIDE(side, distval, dotval, margin, normal) if(visible&(1<<side)) do \
     { \
         float dist = distval; \
@@ -1038,9 +1042,13 @@ static bool cubecollidesolid(physent *d, const vec &dir, float cutoff, const cub
 
     collidewall = vec(0, 0, 0);
     float bestdist = -1e10f;
-    int visible = isentirelysolid(c) ? c.visible : 0xFF, collide = 0;
-    loopi(6) if((visible>>i)&1) collide |=  collidesolidface(c, i, co, size) << i;
-    visible = collide;
+    int visible = isentirelysolid(c) ? c.visible : 0xFF;
+    if(d->type<ENT_CAMERA)
+    {
+        int collide = 0;
+        loopi(6) if((visible>>i)&1) collide |= collidesolidface(c, i, co, size) << i;
+        visible = collide;
+    }
     CHECKSIDE(O_LEFT, co.x - entvol.right(), -dir.x, -d->radius, vec(-1, 0, 0));
     CHECKSIDE(O_RIGHT, entvol.left() - (co.x + size), dir.x, -d->radius, vec(1, 0, 0));
     CHECKSIDE(O_BACK, co.y - entvol.front(), -dir.y, -d->radius, vec(0, -1, 0));
@@ -1185,11 +1193,7 @@ bool collide(physent *d, const vec &dir, float cutoff, bool playercol, bool insi
     ivec bo(int(d->o.x-d->radius), int(d->o.y-d->radius), int(d->o.z-d->height)),
          bs(int(d->o.x+d->radius), int(d->o.y+d->radius), int(d->o.z+d->aboveeye));
     bo.sub(1); bs.add(1);  // guard space for rounding errors
-<<<<<<< HEAD
     return octacollide(d, dir, cutoff, bo, bs) || (playercol && plcollide(d, dir, insideplayercol)); // collide with world
-=======
-    return octacollide(d, dir, cutoff, bo, bs) || (playercol && plcollide(d, dir, insideplayercol));
->>>>>>> ab0663fe... Collide less with occluded faces. Fixes #221.
 }
 
 float pltracecollide(physent *d, const vec &from, const vec &ray, float maxdist)

--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -916,7 +916,7 @@ static bool fuzzycollidesolid(physent *d, const vec &dir, float cutoff, const cu
     collidewall = vec(0, 0, 0);
     float bestdist = -1e10f;
     int visible = isentirelysolid(c) ? c.visible : 0xFF;
-    #define CHECKSIDE(side, distval, dotval, margin, normal) if(visible&(1<<side)) do \
+    #define CHECKSIDE(side, distval, dotval, margin, normal) if(visible&(1<<side) && collidesolidface(c, side, co, size)) do \
     { \
         float dist = distval; \
         if(dist > 0) return false; \
@@ -1181,7 +1181,11 @@ bool collide(physent *d, const vec &dir, float cutoff, bool playercol, bool insi
     ivec bo(int(d->o.x-d->radius), int(d->o.y-d->radius), int(d->o.z-d->height)),
          bs(int(d->o.x+d->radius), int(d->o.y+d->radius), int(d->o.z+d->aboveeye));
     bo.sub(1); bs.add(1);  // guard space for rounding errors
+<<<<<<< HEAD
     return octacollide(d, dir, cutoff, bo, bs) || (playercol && plcollide(d, dir, insideplayercol)); // collide with world
+=======
+    return octacollide(d, dir, cutoff, bo, bs) || (playercol && plcollide(d, dir, insideplayercol));
+>>>>>>> ab0663fe... Collide less with occluded faces. Fixes #221.
 }
 
 float pltracecollide(physent *d, const vec &from, const vec &ray, float maxdist)


### PR DESCRIPTION
Most of the #221 comes from engine checking for collision surfaces that are occluded by it's neighbours. While in theory it doesn't seem feasable to eliminate all such cases, the combination of excluding fully occluded surfaces from collision detection and increasing rounding error margin fixes all the cases I've been able to find or construct.