### PR TITLE
Add usage information to the command console.

### DIFF
--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -107,6 +107,10 @@ ui_hud_displayconsole = [
     ]
 ]
 
+ui_console_colour_var = [
+    result (format "%1 (%2, %3, %4)" (hexcolour $arg1) (& (>> $arg1 16) 0xFF) (& (>> $arg1 8) 0xFF) (& $arg1 0xFF))
+]
+
 ui_hud_showconsole = [
     uivlist 0 [
         uialign -1 -1
@@ -155,6 +159,167 @@ ui_hud_showconsole = [
                                 uitext (getcommandbuf) $ui_textlarge [uitextwrap 0.95; uitextpos (getcommandpos); uitextalign -1; uialign -1 1]
                             ]
                         ] [uiclamp 1 1; uialign -1 -1]
+
+                        local current_command
+                        current_command = (getcommandbuf)
+                        if (=s (substring $current_command 0 1) "/") [
+                            current_command = (substring $current_command 1)
+
+                            // Get start of last id into idname_idx
+                            local idname_idx
+                            idname_idx = 0
+                            local chrlist
+                            chrlist = ";()[]^"$"
+                            loop i (strlen chrlist) [
+                                // strrchr-like functionality
+                                local new_idx
+                                new_idx = 0
+                                local idx_add
+                                idx_add = 0
+                                while [ (!= $new_idx -1) ] [
+                                    new_idx = (strstr (substring $current_command $idx_add) (substring $chrlist $i 1))
+                                    idx_add = (+ $idx_add $new_idx 1)
+                                    // If character found and after last found, use this index
+                                    if (&& (!= $new_idx -1) (> $idx_add $idname_idx ))[
+                                        idname_idx = $idx_add
+                                    ]
+                                ]
+                            ]
+
+                            // Skip any leading whitespace
+                            while [ ( =s (substring (substring $current_command $idname_idx) 0 1) " ") ] [
+                                idname_idx = (+ $idname_idx 1)
+                            ]
+
+                            // Get single id into idname, stopping at next space/tab.
+                            local idname
+                            idname = (substring $current_command $idname_idx)
+                            local idname_end
+                            idname_end = (strstr $idname " ")
+                            if ( = $idname_end -1 ) [
+                                idname_end = (strstr $idname "^t")
+                            ]
+                            if ( = $idname_end -1 ) [
+                                idname_end = (strlen $idname)
+                            ]
+                            idname = (substring $idname 0 $idname_end)
+
+                            if (&& (strlen $idname) ( >= (getvartype $idname) 0)) [
+                                local idtype
+                                idtype = (getvartype $idname)
+                                local idflags
+                                idflags = (getvarflags $idname)
+                                local idtype_s
+                                idtype_s = ""
+                                // IDF_CLIENT || IDF_SERVER
+                                if (|| (& $idflags (<< 1 6)) (& $idflags (<< 1 7))) [
+                                    // IDF_ADMIN
+                                    if (& $idflags (<< 1 9)) [ idtype_s = (concat $idtype_s "admin-only")] [
+                                        // IDF_MODERATOR
+                                        if (& $idflags (<< 1 14)) [ idtype_s = (concat $idtype_s "moderator-only")]
+                                    ]
+                                    // IDF_CLIENT
+                                    idtype_s = (concat $idtype_s (? (& $idflags (<< 1 6)) "game" "server"))
+                                ]
+                                // not ID_COMMAND
+                                if (!= $idtype 3) [
+                                    // IDF_READONLY
+                                    if (& $idflags (<< 1 1)) [ idtype_s = (concat $idtype_s "read-only")]
+                                    // IDF_PERSISTENT
+                                    if (& $idflags (<< 1 0)) [ idtype_s = (concat $idtype_s "persistent")]
+                                    // IDF_WORLD
+                                    if (& $idflags (<< 1 3)) [ idtype_s = (concat $idtype_s "world")]
+                                ]
+
+                                idtype_s = (concat $idtype_s (at "integer float string command alias local" $idtype))
+
+                                uitext $idtype_s $ui_text [uialign -1 1]
+
+                                // ID_VAR
+                                if (= $idtype 0) [
+                                    // IDF_HEX Colour
+                                    if (&& (& $idflags (<< 1 8)) (= (getvarmax $idname) 0xFFFFFF)) [
+                                        uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4^fa [^fs^f[%5]#^fS]" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname)) (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_text [uialign -1 1]
+                                    ] [
+                                        uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getvarmin $idname) (getvarmax $idname) (getvardef $idname) $$idname) $ui_text [uialign -1 1]
+                                    ]
+                                ]
+                                // ID_FVAR
+                                if (= $idtype 1) [
+                                    uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getfvarmin $idname) (getfvarmax $idname) (getfvardef $idname) $$idname) $ui_text [uialign -1 1]
+                                ]
+                                // ID_SVAR
+                                if (= $idtype 2) [
+                                    uitext (format "^fadefault: ^fw%1^fa, current: ^fw%2" (getsvardef $idname) $$idname) $ui_text [uialign -1 1]
+                                ]
+                                // ID_COMMAND
+                                if (= $idtype 3) [
+                                    if (strlen (getvarargs $idname)) [
+                                        uitext (format "^faargs: ^fw%1 ^fa(^fw%2^fa)" (strlen (getvarargs $idname)) (getvarargs $idname)) $ui_text [uialign -1 1]
+                                    ] [
+                                        uitext "^faargs: ^fwnone" $ui_text [uialign -1 1]
+                                    ]
+                                ]
+
+                                local idusage_s
+                                idusage_s = (concatword "Usage: ^fa/" $idname)
+
+                                // ID_VAR Bitfield
+                                if (&& (= $idtype 0) (> (getvarfields $idname) 1)) [
+                                    idusage_s = (concat $idusage_s "<bitfield>")
+                                    uitext $idusage_s $ui_text [uialign -1 1]
+                                    loop i (getvarfields $idname) [
+                                        uitext (format "^t^fa%1 = %2" (<< 1 $i) (getvarfields $idname $i)) $ui_text [uialign -1 1]
+                                    ]
+                                ] [
+                                    if (getvarfields $idname) [
+                                        loop i (getvarfields $idname) [
+                                            if (strlen (getvarfields $idname $i)) [
+                                                idusage_s = (concat $idusage_s (concatword "<" (getvarfields $idname $i) ">"))
+                                            ]
+                                        ]
+                                    ] [
+                                        // ID_ALIAS
+                                        if (= $idtype 4) [ idusage_s = (concat $idusage_s "<arguments>") ]
+                                        // ID_VAR
+                                        if (= $idtype 0) [ idusage_s = (concat $idusage_s "<integer>") ]
+                                        // ID_FVAR
+                                        if (= $idtype 1) [ idusage_s = (concat $idusage_s "<float>") ]
+                                        // ID_SVAR
+                                        if (= $idtype 2) [ idusage_s = (concat $idusage_s "<string>") ]
+                                        // ID_COMMAND
+                                        if (= $idtype 3) [
+                                            loop i (strlen (getvarargs $idname)) [
+                                                local c
+                                                c = (substring (getvarargs $idname) $i 1)
+                                                cases $c s [n = "<string>"
+                                                ] i [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                                ] b [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                                ] n [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                                ] f [n = "<float>"
+                                                ] g [n = "<float>"
+                                                ] t [n = "<null>"
+                                                ] e [n = "<command>"
+                                                ] r [n = "<ident>"
+                                                ] "^$" [n = "<ident>"
+                                                ] () [n = "<?>"]
+                                                idusage_s = (concat $idusage_s $n)
+                                            ]
+                                        ]
+                                    ]
+                                    uitext $idusage_s $ui_text [uialign -1 1]
+                                ]
+
+                                if (strlen (getvardesc $idname)) [
+                                    uitext (concatword "^fa" (getvardesc $idname)) $ui_text [uialign -1 1]
+                                ]
+
+                                // ID_ALIAS
+                                if (= $idtype 4) [
+                                    uitext (concatword "^faContents: ^fw" (getalias $idname)) $ui_textsmall [uialign -1 1]
+                                ]
+                            ]
+                        ]
                     ]
                 ]
             ] [uialign -1 -1]
@@ -612,7 +777,7 @@ ui_hud_timestate = [
                 ] (= (gamemode) $modeidxediting) [
                     uitext Editing $ui_textlarge [uitextlimit 1; uicolourset $colourgreen; uialign 0 0]
                 ] () [
-                    ui_hud_timeremain = (getgametimeremain) 
+                    ui_hud_timeremain = (getgametimeremain)
                     ui_hud_timecolour = (at $ui_hud_timecols (getgamestate))
                     if (getgametimelimit) [
                         uitext (getgamestatestr 1) $ui_text [uitextlimit 1; uicolourset $[colour@[ui_hud_timecolour]]; uialign 0 0]

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -111,6 +111,179 @@ ui_console_colour_var = [
     result (format "%1 (%2, %3, %4)" (tohex $arg1 6) (& (>> $arg1 16) 0xFF) (& (>> $arg1 8) 0xFF) (& $arg1 0xFF))
 ]
 
+ui_console_usage_text = [
+    if $ui_hud_commandopen [
+        uivlist 0 [
+            uialign -1 1
+            local current_command
+            current_command = (getcommandbuf)
+            if (=s (substring $current_command 0 1) "/") [
+                current_command = (substring $current_command 1)
+
+                // Get start of last id into idname_idx
+                local idname_idx
+                idname_idx = 0
+                local chrlist
+                chrlist = ";()[]^"$"
+                loop i (strlen chrlist) [
+                    // strrchr-like functionality
+                    local new_idx
+                    new_idx = 0
+                    local idx_add
+                    idx_add = 0
+                    while [ (!= $new_idx -1) ] [
+                        new_idx = (strstr (substring $current_command $idx_add) (substring $chrlist $i 1))
+                        idx_add = (+ $idx_add $new_idx 1)
+                        // If character found and after last found, use this index
+                        if (&& (!= $new_idx -1) (> $idx_add $idname_idx ))[
+                            idname_idx = $idx_add
+                        ]
+                    ]
+                ]
+
+                // Skip any leading whitespace
+                while [ ( =s (substring (substring $current_command $idname_idx) 0 1) " ") ] [
+                    idname_idx = (+ $idname_idx 1)
+                ]
+
+                // Get single id into idname, stopping at next space/tab.
+                local idname
+                idname = (substring $current_command $idname_idx)
+                local idname_end
+                idname_end = (strstr $idname " ")
+                if ( = $idname_end -1 ) [
+                    idname_end = (strstr $idname "^t")
+                ]
+                if ( = $idname_end -1 ) [
+                    idname_end = (strlen $idname)
+                ]
+                idname = (substring $idname 0 $idname_end)
+
+                if (&& (strlen $idname) ( >= (getvartype $idname) 0)) [
+                    local idtype
+                    idtype = (getvartype $idname)
+                    local idflags
+                    idflags = (getvarflags $idname)
+                    local idtype_s
+                    idtype_s = ""
+                    // IDF_CLIENT || IDF_SERVER
+                    if (|| (& $idflags (<< 1 6)) (& $idflags (<< 1 7))) [
+                        // IDF_ADMIN
+                        if (& $idflags (<< 1 9)) [ idtype_s = (concat $idtype_s "admin-only")] [
+                            // IDF_MODERATOR
+                            if (& $idflags (<< 1 14)) [ idtype_s = (concat $idtype_s "moderator-only")]
+                        ]
+                        // IDF_CLIENT
+                        idtype_s = (concat $idtype_s (? (& $idflags (<< 1 6)) "game" "server"))
+                    ]
+                    // not ID_COMMAND
+                    if (!= $idtype 3) [
+                        // IDF_READONLY
+                        if (& $idflags (<< 1 1)) [ idtype_s = (concat $idtype_s "read-only")]
+                        // IDF_PERSISTENT
+                        if (& $idflags (<< 1 0)) [ idtype_s = (concat $idtype_s "persistent")]
+                        // IDF_WORLD
+                        if (& $idflags (<< 1 3)) [ idtype_s = (concat $idtype_s "world")]
+                    ]
+
+                    idtype_s = (concat $idtype_s (at "integer float string command alias local" $idtype))
+
+                    uitext $idtype_s $ui_text [uialign -1 1]
+
+                    // ID_VAR
+                    if (= $idtype 0) [
+                        // IDF_HEX
+                        if (& $idflags (<< 1 8)) [
+                            // Color
+                            if (= (getvarmax $idname) 0xFFFFFF) [
+                                uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4^fa [^fs^f[%5]#^fS]" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname)) (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_text [uialign -1 1]
+                            ] [
+                                uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (tohex (getvarmin $idname)) (tohex (getvarmax $idname)) (tohex (getvardef $idname)) (tohex $$idname) $$idname) $ui_text [uialign -1 1]
+                            ]
+                        ] [
+                            uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getvarmin $idname) (getvarmax $idname) (getvardef $idname) $$idname) $ui_text [uialign -1 1]
+                        ]
+                    ]
+                    // ID_FVAR
+                    if (= $idtype 1) [
+                        uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getfvarmin $idname) (getfvarmax $idname) (getfvardef $idname) $$idname) $ui_text [uialign -1 1]
+                    ]
+                    // ID_SVAR
+                    if (= $idtype 2) [
+                        uitext (format "^fadefault: ^fw%1^fa, current: ^fw%2" (getsvardef $idname) $$idname) $ui_text [uialign -1 1]
+                    ]
+                    // ID_COMMAND
+                    if (= $idtype 3) [
+                        if (strlen (getvarargs $idname)) [
+                            uitext (format "^faargs: ^fw%1 ^fa(^fw%2^fa)" (strlen (getvarargs $idname)) (getvarargs $idname)) $ui_text [uialign -1 1]
+                        ] [
+                            uitext "^faargs: ^fwnone" $ui_text [uialign -1 1]
+                        ]
+                    ]
+
+                    local idusage_s
+                    idusage_s = (concatword "Usage: ^fa/" $idname)
+
+                    // ID_VAR Bitfield
+                    if (&& (= $idtype 0) (> (getvarfields $idname) 1)) [
+                        idusage_s = (concat $idusage_s "<bitfield>")
+                        uitext $idusage_s $ui_text [uialign -1 1]
+                        loop i (getvarfields $idname) [
+                            uitext (format "^t^fa%1 = %2" (<< 1 $i) (getvarfields $idname $i)) $ui_text [uialign -1 1]
+                        ]
+                    ] [
+                        if (getvarfields $idname) [
+                            loop i (getvarfields $idname) [
+                                if (strlen (getvarfields $idname $i)) [
+                                    idusage_s = (concat $idusage_s (concatword "<" (getvarfields $idname $i) ">"))
+                                ]
+                            ]
+                        ] [
+                            // ID_ALIAS
+                            if (= $idtype 4) [ idusage_s = (concat $idusage_s "<arguments>") ]
+                            // ID_VAR
+                            if (= $idtype 0) [ idusage_s = (concat $idusage_s "<integer>") ]
+                            // ID_FVAR
+                            if (= $idtype 1) [ idusage_s = (concat $idusage_s "<float>") ]
+                            // ID_SVAR
+                            if (= $idtype 2) [ idusage_s = (concat $idusage_s "<string>") ]
+                            // ID_COMMAND
+                            if (= $idtype 3) [
+                                loop i (strlen (getvarargs $idname)) [
+                                    local c
+                                    c = (substring (getvarargs $idname) $i 1)
+                                    cases $c s [n = "<string>"
+                                    ] i [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                    ] b [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                    ] n [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
+                                    ] f [n = "<float>"
+                                    ] g [n = "<float>"
+                                    ] t [n = "<null>"
+                                    ] e [n = "<command>"
+                                    ] r [n = "<ident>"
+                                    ] "^$" [n = "<ident>"
+                                    ] () [n = "<?>"]
+                                    idusage_s = (concat $idusage_s $n)
+                                ]
+                            ]
+                        ]
+                        uitext $idusage_s $ui_text [uialign -1 1]
+                    ]
+
+                    if (strlen (getvardesc $idname)) [
+                        uitext (concatword "^fa" (getvardesc $idname)) $ui_text [uialign -1 1]
+                    ]
+
+                    // ID_ALIAS
+                    if (= $idtype 4) [
+                        uitext (concatword "^faContents: ^fw" (getalias $idname)) $ui_textsmall [uialign -1 1]
+                    ]
+                ]
+            ]
+        ]
+    ]
+]
+
 ui_hud_showconsole = [
     uivlist 0 [
         uialign -1 -1
@@ -159,172 +332,6 @@ ui_hud_showconsole = [
                                 uitext (getcommandbuf) $ui_textlarge [uitextwrap 0.95; uitextpos (getcommandpos); uitextalign -1; uialign -1 1]
                             ]
                         ] [uiclamp 1 1; uialign -1 -1]
-
-                        local current_command
-                        current_command = (getcommandbuf)
-                        if (=s (substring $current_command 0 1) "/") [
-                            current_command = (substring $current_command 1)
-
-                            // Get start of last id into idname_idx
-                            local idname_idx
-                            idname_idx = 0
-                            local chrlist
-                            chrlist = ";()[]^"$"
-                            loop i (strlen chrlist) [
-                                // strrchr-like functionality
-                                local new_idx
-                                new_idx = 0
-                                local idx_add
-                                idx_add = 0
-                                while [ (!= $new_idx -1) ] [
-                                    new_idx = (strstr (substring $current_command $idx_add) (substring $chrlist $i 1))
-                                    idx_add = (+ $idx_add $new_idx 1)
-                                    // If character found and after last found, use this index
-                                    if (&& (!= $new_idx -1) (> $idx_add $idname_idx ))[
-                                        idname_idx = $idx_add
-                                    ]
-                                ]
-                            ]
-
-                            // Skip any leading whitespace
-                            while [ ( =s (substring (substring $current_command $idname_idx) 0 1) " ") ] [
-                                idname_idx = (+ $idname_idx 1)
-                            ]
-
-                            // Get single id into idname, stopping at next space/tab.
-                            local idname
-                            idname = (substring $current_command $idname_idx)
-                            local idname_end
-                            idname_end = (strstr $idname " ")
-                            if ( = $idname_end -1 ) [
-                                idname_end = (strstr $idname "^t")
-                            ]
-                            if ( = $idname_end -1 ) [
-                                idname_end = (strlen $idname)
-                            ]
-                            idname = (substring $idname 0 $idname_end)
-
-                            if (&& (strlen $idname) ( >= (getvartype $idname) 0)) [
-                                local idtype
-                                idtype = (getvartype $idname)
-                                local idflags
-                                idflags = (getvarflags $idname)
-                                local idtype_s
-                                idtype_s = ""
-                                // IDF_CLIENT || IDF_SERVER
-                                if (|| (& $idflags (<< 1 6)) (& $idflags (<< 1 7))) [
-                                    // IDF_ADMIN
-                                    if (& $idflags (<< 1 9)) [ idtype_s = (concat $idtype_s "admin-only")] [
-                                        // IDF_MODERATOR
-                                        if (& $idflags (<< 1 14)) [ idtype_s = (concat $idtype_s "moderator-only")]
-                                    ]
-                                    // IDF_CLIENT
-                                    idtype_s = (concat $idtype_s (? (& $idflags (<< 1 6)) "game" "server"))
-                                ]
-                                // not ID_COMMAND
-                                if (!= $idtype 3) [
-                                    // IDF_READONLY
-                                    if (& $idflags (<< 1 1)) [ idtype_s = (concat $idtype_s "read-only")]
-                                    // IDF_PERSISTENT
-                                    if (& $idflags (<< 1 0)) [ idtype_s = (concat $idtype_s "persistent")]
-                                    // IDF_WORLD
-                                    if (& $idflags (<< 1 3)) [ idtype_s = (concat $idtype_s "world")]
-                                ]
-
-                                idtype_s = (concat $idtype_s (at "integer float string command alias local" $idtype))
-
-                                uitext $idtype_s $ui_text [uialign -1 1]
-
-                                // ID_VAR
-                                if (= $idtype 0) [
-                                    // IDF_HEX
-                                    if (& $idflags (<< 1 8)) [
-                                        // Color
-                                        if (= (getvarmax $idname) 0xFFFFFF) [
-                                            uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4^fa [^fs^f[%5]#^fS]" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname)) (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_text [uialign -1 1]
-                                        ] [
-                                            uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (tohex (getvarmin $idname)) (tohex (getvarmax $idname)) (tohex (getvardef $idname)) (tohex $$idname) $$idname) $ui_text [uialign -1 1]
-                                        ]
-                                    ] [
-                                        uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getvarmin $idname) (getvarmax $idname) (getvardef $idname) $$idname) $ui_text [uialign -1 1]
-                                    ]
-                                ]
-                                // ID_FVAR
-                                if (= $idtype 1) [
-                                    uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getfvarmin $idname) (getfvarmax $idname) (getfvardef $idname) $$idname) $ui_text [uialign -1 1]
-                                ]
-                                // ID_SVAR
-                                if (= $idtype 2) [
-                                    uitext (format "^fadefault: ^fw%1^fa, current: ^fw%2" (getsvardef $idname) $$idname) $ui_text [uialign -1 1]
-                                ]
-                                // ID_COMMAND
-                                if (= $idtype 3) [
-                                    if (strlen (getvarargs $idname)) [
-                                        uitext (format "^faargs: ^fw%1 ^fa(^fw%2^fa)" (strlen (getvarargs $idname)) (getvarargs $idname)) $ui_text [uialign -1 1]
-                                    ] [
-                                        uitext "^faargs: ^fwnone" $ui_text [uialign -1 1]
-                                    ]
-                                ]
-
-                                local idusage_s
-                                idusage_s = (concatword "Usage: ^fa/" $idname)
-
-                                // ID_VAR Bitfield
-                                if (&& (= $idtype 0) (> (getvarfields $idname) 1)) [
-                                    idusage_s = (concat $idusage_s "<bitfield>")
-                                    uitext $idusage_s $ui_text [uialign -1 1]
-                                    loop i (getvarfields $idname) [
-                                        uitext (format "^t^fa%1 = %2" (<< 1 $i) (getvarfields $idname $i)) $ui_text [uialign -1 1]
-                                    ]
-                                ] [
-                                    if (getvarfields $idname) [
-                                        loop i (getvarfields $idname) [
-                                            if (strlen (getvarfields $idname $i)) [
-                                                idusage_s = (concat $idusage_s (concatword "<" (getvarfields $idname $i) ">"))
-                                            ]
-                                        ]
-                                    ] [
-                                        // ID_ALIAS
-                                        if (= $idtype 4) [ idusage_s = (concat $idusage_s "<arguments>") ]
-                                        // ID_VAR
-                                        if (= $idtype 0) [ idusage_s = (concat $idusage_s "<integer>") ]
-                                        // ID_FVAR
-                                        if (= $idtype 1) [ idusage_s = (concat $idusage_s "<float>") ]
-                                        // ID_SVAR
-                                        if (= $idtype 2) [ idusage_s = (concat $idusage_s "<string>") ]
-                                        // ID_COMMAND
-                                        if (= $idtype 3) [
-                                            loop i (strlen (getvarargs $idname)) [
-                                                local c
-                                                c = (substring (getvarargs $idname) $i 1)
-                                                cases $c s [n = "<string>"
-                                                ] i [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
-                                                ] b [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
-                                                ] n [n = (? (& $idflags (<< 1 8)) "<bitfield>" "<integer>")
-                                                ] f [n = "<float>"
-                                                ] g [n = "<float>"
-                                                ] t [n = "<null>"
-                                                ] e [n = "<command>"
-                                                ] r [n = "<ident>"
-                                                ] "^$" [n = "<ident>"
-                                                ] () [n = "<?>"]
-                                                idusage_s = (concat $idusage_s $n)
-                                            ]
-                                        ]
-                                    ]
-                                    uitext $idusage_s $ui_text [uialign -1 1]
-                                ]
-
-                                if (strlen (getvardesc $idname)) [
-                                    uitext (concatword "^fa" (getvardesc $idname)) $ui_text [uialign -1 1]
-                                ]
-
-                                // ID_ALIAS
-                                if (= $idtype 4) [
-                                    uitext (concatword "^faContents: ^fw" (getalias $idname)) $ui_textsmall [uialign -1 1]
-                                ]
-                            ]
-                        ]
                     ]
                 ]
             ] [uialign -1 -1]

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -108,7 +108,7 @@ ui_hud_displayconsole = [
 ]
 
 ui_console_colour_var = [
-    result (format "%1 (%2, %3, %4)" (hexcolour $arg1) (& (>> $arg1 16) 0xFF) (& (>> $arg1 8) 0xFF) (& $arg1 0xFF))
+    result (format "%1 (%2, %3, %4)" (tohex $arg1 6) (& (>> $arg1 16) 0xFF) (& (>> $arg1 8) 0xFF) (& $arg1 0xFF))
 ]
 
 ui_hud_showconsole = [
@@ -237,9 +237,14 @@ ui_hud_showconsole = [
 
                                 // ID_VAR
                                 if (= $idtype 0) [
-                                    // IDF_HEX Colour
-                                    if (&& (& $idflags (<< 1 8)) (= (getvarmax $idname) 0xFFFFFF)) [
-                                        uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4^fa [^fs^f[%5]#^fS]" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname)) (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_text [uialign -1 1]
+                                    // IDF_HEX
+                                    if (& $idflags (<< 1 8)) [
+                                        // Color
+                                        if (= (getvarmax $idname) 0xFFFFFF) [
+                                            uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4^fa [^fs^f[%5]#^fS]" (ui_console_colour_var (getvarmin $idname)) (ui_console_colour_var (getvarmax $idname)) (ui_console_colour_var (getvardef $idname)) (ui_console_colour_var $$idname) $$idname) $ui_text [uialign -1 1]
+                                        ] [
+                                            uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (tohex (getvarmin $idname)) (tohex (getvarmax $idname)) (tohex (getvardef $idname)) (tohex $$idname) $$idname) $ui_text [uialign -1 1]
+                                        ]
                                     ] [
                                         uitext (format "^famin: ^fw%1^fa, max: ^fw%2^fa, default: ^fw%3^fa, current: ^fw%4" (getvarmin $idname) (getvarmax $idname) (getvardef $idname) $$idname) $ui_text [uialign -1 1]
                                     ]

--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -856,6 +856,13 @@ void getvarfields(const char *name, int prop)
     else result("");
 }
 
+const char *getvarargs(const char *name)
+{
+    ident *id = getident(name);
+    if(!id || !id->args) return "";
+    return id->args;
+}
+
 ICOMMAND(0, getvar, "s", (char *n), intret(getvar(n)));
 ICOMMAND(0, getvartype, "s", (char *n), intret(getvartype(n)));
 ICOMMAND(0, getvarflags, "s", (char *n), intret(getvarflags(n)));
@@ -868,6 +875,7 @@ ICOMMAND(0, getfvardef, "si", (char *n, int *b), floatret(getfvardef(n, *b!=0)))
 ICOMMAND(0, getsvardef, "si", (char *n, int *b), result(getsvardef(n, *b!=0)));
 ICOMMAND(0, getvardesc, "s", (char *n), result(getvardesc(n)));
 ICOMMAND(0, getvarfields, "sb", (char *n, int *p), getvarfields(n, *p));
+ICOMMAND(0, getvarargs, "s", (char *n), result(getvarargs(n)));
 
 bool identexists(const char *name) { return idents.access(name)!=NULL; }
 ident *getident(const char *name) { return idents.access(name); }


### PR DESCRIPTION
This is a port of the old C++ usage display into modern Cubescript.

Potential problems and stuff I need help with:
* The first line (the type information) is offset a little way to the right relative to the rest of the usage text.
* Long descriptions and alias content, or descriptions and alias content with newlines end up with weird formatting, as seen in the included screenshots.
* I had to implement the strrchr and strcspn segment that determines the id name as I could not find Cubescript equivalents, is there a better way to do this?
* I use raw numbers (with comments) for id flags and types (ID_COMMAND, IDF_HEX, etc.), is there a better way to do this?
* I added a command `getvarargs` to access raw command argument information.

![2017-10-25-154606_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020172-4eeae5fa-b99d-11e7-90ca-857762deccb3.png)
![2017-10-25-154808_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020175-4f139f7c-b99d-11e7-91ca-006119c13d0e.png)
![2017-10-25-154818_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020177-4f32ece2-b99d-11e7-94e5-483179b66467.png)
![2017-10-25-154823_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020178-4f5533b0-b99d-11e7-8a43-c6175237588d.png)
![2017-10-25-155044_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020179-4f7865b0-b99d-11e7-9177-110d02120a6b.png)
![2017-10-25-155052_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020180-4fa9db04-b99d-11e7-82f4-496b24ba8484.png)
![2017-10-25-155103_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020181-4fced2ba-b99d-11e7-9b76-729d29b64c49.png)
![2017-10-25-155225_1916x1009_scrot](https://user-images.githubusercontent.com/2333388/32020183-4fedb63a-b99d-11e7-9d1b-a01384b5a821.png)







