### PR TITLE
Add appimage builds to semaphore.

### DIFF
--- a/src/semaphore_appimage.sh
+++ b/src/semaphore_appimage.sh
@@ -2,6 +2,8 @@
 
 SEMABUILD_APT='DEBIAN_FRONTEND=noninteractive apt-get'
 
+RE_SOURCE="$(readlink -f "$(dirname "$(readlink -f "$0")")/..")"
+
 semabuild_appimage() {
     git clone https://github.com/red-eclipse/appimage-builder.git
 
@@ -13,10 +15,10 @@ semabuild_appimage() {
     export BUILD_SERVER=1
     export BUILD_CLIENT=1
     # Build the appimages.
-    bash build-with-docker.sh || exit 1
+    bash build-with-docker.sh "$RE_SOURCE" || exit 1
     # Release parameters.
-    export GITHUB_TOKEN=${APPIMAGE_GITHUB_TOKEN}
-    # Release the appimages
+    export GITHUB_TOKEN=${GITHUB_TOKEN}
+    # Release the appimages.
     bash github-release.sh || exit 1
     popd
     return 0

--- a/src/semaphore_appimage.sh
+++ b/src/semaphore_appimage.sh
@@ -14,6 +14,9 @@ semabuild_appimage() {
     export COMMIT=$(git rev-parse HEAD)
     export BUILD_SERVER=1
     export BUILD_CLIENT=1
+    export PLATFORM_BUILD=${SEMAPHORE_BUILD_NUMBER}
+    export PLATFORM_BRANCH=${BRANCH_NAME}
+    export PLATFORM_REVISION=${REVISION}
     # Build the appimages.
     bash build-with-docker.sh "$RE_SOURCE" || exit 1
     # Release parameters.

--- a/src/semaphore_appimage.sh
+++ b/src/semaphore_appimage.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+SEMABUILD_APT='DEBIAN_FRONTEND=noninteractive apt-get'
+
+semabuild_appimage() {
+    git clone https://github.com/red-eclipse/appimage-builder.git
+
+    pushd appimage-builder
+    export BRANCH=${BRANCH_NAME}
+    # Build parameters.
+    export ARCH=x86_64
+    export COMMIT=$(git rev-parse HEAD)
+    export BUILD_SERVER=1
+    export BUILD_CLIENT=1
+    # Build the appimages.
+    bash build-with-docker.sh || exit 1
+    # Release parameters.
+    export GITHUB_TOKEN=${APPIMAGE_GITHUB_TOKEN}
+    # Release the appimages
+    bash github-release.sh || exit 1
+    popd
+    return 0
+}
+
+if [ "${BRANCH_NAME}" = master ] || [ "${BRANCH_NAME}" = stable ]; then
+    # Install jq for Github API and zsync for AppImage update information.
+    sudo ${SEMABUILD_APT} -fy install jq zsync || exit 1
+    semabuild_appimage || exit 1
+fi


### PR DESCRIPTION
This script will build and release AppImages, for use with the current SemaphoreCI builds. It uses the [appimage-builder](https://github.com/red-eclipse/appimage-builder) repository for the bulk of functionality. Please review that repository (particularly `build-with-docker.sh` and `github-release.sh`) as well as this pull request.

The semaphore rule to call this script (`bash src/semaphore_appimage.sh`) could be run after or alongside the current build and deployment.

<strike>The appimage build currently re-clones data within its docker container for the built branch, in the future, if possible, I intend to have it use the data already available for the build.</strike>

After building the appimage, the script will then create a new release `appimage_continuous_<branch>` on [red-eclipse/deploy](https://github.com/red-eclipse/deploy), overwriting <strike>any previous releases</strike> any previous release of this name.

@qreeves the platform for SemaphoreCI will need to be changed to enable Docker (as AppImages should be built on older systems, debian oldstable in this case), this should be a simple toggle and have no effect on other build scripts. A github API repo token must also be placed in the envvar <strike>`APPIMAGE_GITHUB_TOKEN`</strike> `GITHUB_TOKEN`.

These redirects (I'm unsure how to configure them myself) must be set up for portable URLs to AppImage and zsync data:

Simpler generic redirects, just redirect `/appimage/<branch>/<file>` to the appropriate release: 
* `https://redeclipse.net/appimage/master/<file>` -> `https://github.com/red-eclipse/deploy/releases/download/appimage_continuous_master/<file>`
* `https://redeclipse.net/appimage/stable/<file>` -> `https://github.com/red-eclipse/deploy/releases/download/appimage_continuous_stable/<file>`

After confirmation of successful behaviour on the master branch, this script should be merged into stable to begin AppImage builds as soon as possible there as well.