### PR TITLE
Reverse complete upon Shift+Tab.

### DIFF
--- a/src/engine/console.cpp
+++ b/src/engine/console.cpp
@@ -615,7 +615,7 @@ bool consolekey(int code, bool isdown)
             case SDLK_TAB:
                 if(commandflags&CF_COMPLETE)
                 {
-                    complete(commandbuf, commandflags&CF_EXECUTE ? "/" : NULL);
+                    complete(commandbuf, commandflags&CF_EXECUTE ? "/" : NULL, SDL_GetModState()&KMOD_SHIFT);
                     if(commandpos>=0 && commandpos>=(int)strlen(commandbuf)) commandpos = -1;
                 }
                 break;
@@ -850,7 +850,7 @@ void addlistcomplete(char *command, char *list)
 COMMANDN(0, complete, addfilecomplete, "sss");
 COMMANDN(0, listcomplete, addlistcomplete, "ss");
 
-void complete(char *s, const char *cmdprefix)
+void complete(char *s, const char *cmdprefix, bool reverse)
 {
     char *start = s;
     if(cmdprefix)
@@ -894,7 +894,7 @@ void complete(char *s, const char *cmdprefix)
         loopv(f->files)
         {
             if(strncmp(f->files[i], &start[commandsize], completesize-commandsize)==0 &&
-                strcmp(f->files[i], lastcomplete) > 0 && (!nextcomplete || strcmp(f->files[i], nextcomplete) < 0))
+                strcmp(f->files[i], lastcomplete) * (reverse ? -1 : 1) > 0 && (!nextcomplete || strcmp(f->files[i], nextcomplete) * (reverse ? -1 : 1) < 0))
                 nextcomplete = f->files[i];
         }
     }
@@ -902,7 +902,7 @@ void complete(char *s, const char *cmdprefix)
     {
         enumerate(idents, ident, id,
             if((variable ? id.type == ID_VAR || id.type == ID_SVAR || id.type == ID_FVAR || id.type == ID_ALIAS: id.flags&IDF_COMPLETE) && strncmp(id.name, start, completesize)==0 &&
-               strcmp(id.name, lastcomplete) > 0 && (!nextcomplete || strcmp(id.name, nextcomplete) < 0))
+               strcmp(id.name, lastcomplete) * (reverse ? -1 : 1) > 0 && (!nextcomplete || strcmp(id.name, nextcomplete) * (reverse ? -1 : 1) < 0))
                 nextcomplete = id.name;
         );
     }

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -135,7 +135,7 @@ extern int changedkeys;
 extern void processtextinput(const char *str, int len);
 extern void processkey(int code, bool isdown);
 extern void resetcomplete();
-extern void complete(char *s, const char *cmdprefix);
+extern void complete(char *s, const char *cmdprefix, bool reverse);
 extern const char *searchbind(const char *action, int type);
 extern void searchbindlist(const char *action, int type, int limit, const char *s1, const char *s2, const char *sep1, const char *sep2, vector<char> &names, bool force = true);
 


### PR DESCRIPTION
This is a simple pull request that adds functionality to command/file completion so that when shift is held, tab completion will compare and move backward, in reverse order.

Requested by @acerspyro.