### PR TITLE
Change the editbindvar for showmat from PLUS to M

### DIFF
--- a/config/setup.cfg
+++ b/config/setup.cfg
@@ -222,7 +222,7 @@ editbind 0          [ domodifier 20 ]
 editbind K          [ domodifier 9 ]
 
 editbindvar MINUS   allfaces
-editbindvar PLUS    showmat
+editbindvar M       showmat
 editbindvar EQUALS  outline
 
 


### PR DESCRIPTION
I don't think the plus key ever worked to toggle showmat in edit mode.

Either way, the M key is standard in other cube games and is currently unused in Red Eclipse's edit mode bindings.