### PR TITLE
Use day variant for `day` vars instead of `all`.

### DIFF
--- a/src/engine/rendersky.cpp
+++ b/src/engine/rendersky.cpp
@@ -108,7 +108,7 @@ Texture *loadskyoverlay(const char *basename)
     VAR(IDF_WORLD, skytexture##name, 0, 0, 1); \
     VARF(IDF_WORLD, skyshadow##name, 0, 0, 1, if(checkmapvariant(type)) clearshadowcache());
 
-DAYNIGHTVARS(, 0);
+DAYNIGHTVARS(, MPV_DAY);
 DAYNIGHTVARS(night, MPV_NIGHT);
 
 #define GETDAYNIGHT(name, type) \


### PR DESCRIPTION
There's currently an issue that `skyboxnight` won't load with night `mapvariant`. Or actually it's loaded but then replaced by `skybox` because the hook for it is triggered and `checkmapvariant` returns `true` on it. Same probably for other hooks that use `checkmapvariant`.