### PR TITLE
Add Acerspyro's textures to the available textures pool

### DIFF
--- a/config/map/textures.cfg
+++ b/config/map/textures.cfg
@@ -1,3 +1,4 @@
+exec "acerspyro/textures.cfg"
 exec "appleflap/textures.cfg"
 exec "dziq/textures.cfg"
 exec "jojo/textures.cfg"


### PR DESCRIPTION
My textures were missing from the textures pool in config/map/textures.cfg for some reason.