### PR TITLE
Add allconsole variable that displays all consoles like fullconsole but with usual fading for less intrusiveness.

### DIFF
--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -4,6 +4,7 @@ defvarp showvelocity 0 1 1
 defvarp showtimestyle 0 3 4
 defvarp showconsole 0 1 1
 
+defvar allconsole 0 0 1
 defvar fullconsole 0 0 1
 toggleconsole = [fullconsole (! $fullconsole)]
 
@@ -351,8 +352,10 @@ ui_hud_showconsole = [
                 ]
             ] [uialign -1 -1]
         ] [
-            loop i (? $fullconsole 4 (? (isconnected) 2 3)) [
-                ui_hud_displayconsole (? $fullconsole $i (+ $i 1)) (- $conlines) (? $fullconsole 0 $conouttime) (? $fullconsole 0 $confadetime) (? $fullconsole 0 $conintime) (? $fullconsole 1 $conblend) 1
+            local showall
+            showall = (|| $fullconsole $allconsole)
+            loop i (? $showall 4 (? (isconnected) 2 3)) [
+                ui_hud_displayconsole (? $showall $i (+ $i 1)) (- $conlines) (? $fullconsole 0 $conouttime) (? $fullconsole 0 $confadetime) (? $fullconsole 0 $conintime) (? $fullconsole 1 $conblend) 1
             ]
         ]
     ]


### PR DESCRIPTION
It can be useful to display all console levels (particularly Debug, due to echo/error) on screen without the potential intrusiveness of `fullconsole`'s constant display. This adds a variable `allconsole` for this purpose.

The variable name could possibly be improved, I considered making it a second value of `fullconsole` as well.