### PR TITLE
Do not autospectate in duel and survivor.

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -5227,7 +5227,7 @@ namespace server
                     sendspawn(ci);
                 }
             }
-            if(G(autospectate) && ci->state == CS_DEAD && ci->lastdeath && gamemillis-ci->lastdeath >= G(autospecdelay))
+            if(G(autospectate) && !m_duke(gamemode, mutators) && ci->state == CS_DEAD && ci->lastdeath && gamemillis-ci->lastdeath >= G(autospecdelay))
                 spectate(ci, true);
         }
     }


### PR DESCRIPTION
In duke mutators, players who die early may remain dead for over `autospecdelay` milliseconds (60 seconds by default). This causes them to be removed from the automatic respawn queue, and if they do not re-enter the game manually when this happens, they can miss the next round entirely.

This pull request simply disables the autospectate functionality entirely for duke mutators, as this behaviour is disruptive to the game.