### PR TITLE
Bitfield vanity styles.

### DIFF
--- a/config/vanities.cfg
+++ b/config/vanities.cfg
@@ -4,7 +4,7 @@ resetvanity
 // name:   friendly name for viewing
 // tag:    tag on player where vanity attaches
 // cond:   bitwise: 1 = not on first person body, 2 = not on headless model (and makes a projectile)
-// style:  add folder for: 1= player priv level, 2 = player model
+// style:  bitwise: add folder for (in ascending order if multiple styles used): 1= player priv level, 2 = player model
 //     zone     model                   name                tag              cond   style   // zone name
 addvanity 0     "badge"                 "badge"             "tag_badge"         1   1       // chest
 addvanity 0     "chestplate"            "chestplate"        "tag_badge"         1           // chest


### PR DESCRIPTION
Converts vanity style field to a bitfield, allowing multiple styles to be used for one vanity.

To combine priv and model use style 3 (which is `1 | 2`), the resulting vanity path will be something like `badge/none/male`.

Closes #793
