### PR TITLE
Fix period in quit warning

### DIFF
--- a/config/ui/package.cfg
+++ b/config/ui/package.cfg
@@ -52,7 +52,7 @@ uimenu "quitwarn" "Quit" $alerttex [
     uivlist $ui_padbutton [
         uivlist 0 [
             uitext "Are you sure you want to quit?"
-            uitext "All unsaved changes will be lost"
+            uitext "All unsaved changes will be lost."
         ]
         uibar 1 0
         uihlist $ui_padbutton [


### PR DESCRIPTION
For the edit mode exit popup in commit e1ea5654d38385f4e580dbe656b91620a3e2eae1


