### PR TITLE
Enable above head team icons for team mates by default

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -223,7 +223,7 @@ namespace game
     VAR(IDF_PERSIST, aboveheadnames, 0, 1, 1);
     VAR(IDF_PERSIST, aboveheadinventory, 0, 0, 2); // 0 = off, 1 = weapselect only, 2 = all weapons
     VAR(IDF_PERSIST, aboveheadstatus, 0, 1, 1);
-    VAR(IDF_PERSIST, aboveheadteam, 0, 0, 3);
+    VAR(IDF_PERSIST, aboveheadteam, 0, 1, 3);
     VAR(IDF_PERSIST, aboveheaddamage, 0, 0, 1);
     VAR(IDF_PERSIST, aboveheadicons, 0, 5, 7);
     FVAR(IDF_PERSIST, aboveheadblend, 0.f, 1, 1.f);


### PR DESCRIPTION
This makes above head team icons display above team mates, as in old Red Eclipse versions. (For some reason, 1.6.0 defaulted this value to 3 which also displayed the icon above enemies.)