### PR TITLE
Settings menu additions

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -305,9 +305,23 @@ uimenu "settings" "Settings" "textures/icons/settings" [
 
                                 
                             ] 4 [
-                                uitablerow [
-                                    uitext "Not implemented yet. ^nCheck again later!"
+                               uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Mouse Sensitivity"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "sensitivity" 1 50 1 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext $sensitivity
+                                            ]
+                                        ]
+                                        uialign 1 0
+                                    ]
                                 ]
+
                             ] 5 [
                                 uitablerow [
                                     uitext "Not implemented yet. ^nCheck again later!"

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -135,6 +135,17 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         1024    @(format "%1Distant"    (? $grass "^f3" "^f4")) []
                                     ] [uialign 1 0]
                                 ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uicheckbox "Map Effects" $mapeffects $ui_checksize [mapeffects = (! $mapeffects)]
+                                        uialign -1 0
+                                    ]
+                                    uiselect 0.2 0.025 "mapeffects" [
+                                        0     @(format "%1Low"       (? $grass "^f0" "^f4")) []
+                                        1     @(format "%1Medium"   (? $grass "^f2" "^f4")) []
+                                        2     @(format "%1High"        (? $grass "^f6" "^f4")) []
+                                    ] [uialign 1 0]
+                                ]
                             ] 1 [
                                 uitablerow [
                                     uihlist $ui_padbutton [

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -281,6 +281,30 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uialign 1 0
                                     ]
                                 ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Framerate Cap"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "maxfps" 5 200 1 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext $maxfps
+                                                    
+                                            ]
+                                        ]
+                                        uialign 1 0
+                                    ]
+                                ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uicheckbox "Vertical Sync" $vsync $ui_checksize [vsync = (! $vsync)]
+                                        uialign -1 0
+                                    ]
+                                ]
+
                             ] 2 [
                                 uitablerow [
                                     uitext "Not implemented yet. ^nCheck again later!"

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -135,19 +135,35 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         1024    @(format "%1Distant"    (? $grass "^f3" "^f4")) []
                                     ] [uialign 1 0]
                                 ]
-                                 uitablerow [
+                                uitablerow [
                                     uihlist $ui_padbutton [
                                         uifill $ui_checksize
                                         uitextleft "Map Effects"
                                         uialign -1 0
                                     ]
                                     uiselect 0.2 0.025 "mapeffects" [
-                                        0 "^f4Low"          []
-                                        1 "^f0Medium"          []
-                                        2 "^f2High"       []
+                                        0 "^f0Low"          []
+                                        1 "^f2Medium"          []
+                                        2 "^f6High"       []
                                     ] [uialign 1 0]
                                 ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Texture Quality"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "texreduce" 0 12 1 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- $texreduce -2) 8) 1 0.5)) $texreduce)
 
+                                            ]
+                                        ]
+                                        uialign 1 0
+                                    ]
+                                ]
                                 
                             ] 1 [
                                 uitablerow [
@@ -160,7 +176,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "gscale" 25 100 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- $gscale 25) 1.6) 1 0.5)) $gscale)
+                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- 100 $gscale) 1.6) 1 0.5)) $gscale)
                                             ]
                                         ]
                                         uialign 1 0

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -287,8 +287,23 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                 ]
                             ] 3 [
                                 uitablerow [
-                                    uitext "Not implemented yet. ^nCheck again later!"
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Player Model Brightness"
+                                        uialign -1 0
+                                    ]
+                                    uihlist $ui_padbutton [
+                                        uihorzslider "fullbrightmodels" 0 200 1 0.2 0.025 [
+                                            uivlist 0 [
+                                                uifill 0.050 0
+                                                uitext $fullbrightmodels
+                                            ]
+                                        ]
+                                        uialign 1 0
+                                    ]
                                 ]
+
+                                
                             ] 4 [
                                 uitablerow [
                                     uitext "Not implemented yet. ^nCheck again later!"

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -135,17 +135,20 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         1024    @(format "%1Distant"    (? $grass "^f3" "^f4")) []
                                     ] [uialign 1 0]
                                 ]
-                                uitablerow [
+                                 uitablerow [
                                     uihlist $ui_padbutton [
-                                        uicheckbox "Map Effects" $mapeffects $ui_checksize [mapeffects = (! $mapeffects)]
+                                        uifill $ui_checksize
+                                        uitextleft "Map Effects"
                                         uialign -1 0
                                     ]
                                     uiselect 0.2 0.025 "mapeffects" [
-                                        0     @(format "%1Low"       (? $grass "^f0" "^f4")) []
-                                        1     @(format "%1Medium"   (? $grass "^f2" "^f4")) []
-                                        2     @(format "%1High"        (? $grass "^f6" "^f4")) []
+                                        0 "^f4Low"          []
+                                        1 "^f0Medium"          []
+                                        2 "^f2High"       []
                                     ] [uialign 1 0]
                                 ]
+
+                                
                             ] 1 [
                                 uitablerow [
                                     uihlist $ui_padbutton [


### PR DESCRIPTION
This PR adds the following to the settings menu:
### Graphics
mapeffects (low, medium, high) to go alongside the new fxlevel attribute
texreduce (slider, 0 to 12) to blur textures if more plain walls are desired, etc.
### Display
renderscale (color reversed, higher is now red)
maxfps (slider, 5 to 200)
vsync (on/off)
### Gameplay
fullbrightmodels (slider, 0 to 200) for brightning mmodels 
### Controls
sensitivity (slider, 1 to 50) 

Screenshots in master:3180.
![20180715224644](https://user-images.githubusercontent.com/23445929/42744394-27b0ee0e-8881-11e8-91ac-abb10dc0098a.png)
![20180715224642](https://user-images.githubusercontent.com/23445929/42744395-27c5566e-8881-11e8-8418-564947783a6f.png)
![20180715224640](https://user-images.githubusercontent.com/23445929/42744396-27e5c1d8-8881-11e8-97fd-2ba5cc6d4279.png)
![20180715224638](https://user-images.githubusercontent.com/23445929/42744397-27f922dc-8881-11e8-84f7-b314367a6868.png)
