### PR TITLE
Procedural vegetation animation

### DIFF
--- a/config/glsl/model.cfg
+++ b/config/glsl/model.cfg
@@ -62,9 +62,63 @@ skelanim = [
     ]
 ]
 
+// Cubic Bezier periodic wave function
+cbezier = [
+    result [
+        float cbezier(float x) { return (mod(x, 2) * (mod(x, 2) - 1) * (mod(x, 2) - 2)) * 2.5; }
+    ]
+]
+
+vegetationwind = [
+    result [
+        if(vegetationanim)
+        {
+#define VEG_ANIM_FREQ 0.4
+#define VEG_ANIM_MAIN_SWAY_FORCE 0.01
+#define VEG_ANIM_DETAIL_PHASE_SHIFT_FACTOR 10
+#define VEG_ANIM_MIN_FORCE 0.1
+#define VEG_ANIM_FORCE_FREQ 0.04
+#define VEG_ANIM_DETAIL_FREQ 3
+#define VEG_ANIM_LEAF_FREQ 10
+#define VEG_ANIM_LEAF_STRENGTH vec3(0.25, 0.25, 0.5)
+#define VEG_ANIM_AXIS_PHASE_SHIFT 0.5
+
+            // Global phase for the animation
+            float theta = (millis + vegetationphase) * VEG_ANIM_FREQ;
+            
+            // Phase for the detail animation (vertex color, green channel factored in)
+            float detailphase = (theta) + (vcolor.y * VEG_ANIM_DETAIL_PHASE_SHIFT_FACTOR);
+            
+            // Global force modifier, not dependent on the phase shift
+            float force = max(VEG_ANIM_MIN_FORCE, cbezier(millis * VEG_ANIM_FORCE_FREQ) + 1);
+
+            // Main sway
+            wind.xy += vec2(cbezier(theta),
+                            cbezier(theta + VEG_ANIM_AXIS_PHASE_SHIFT)) *
+                       mpos.z * force * VEG_ANIM_MAIN_SWAY_FORCE;
+            
+            // Detail sway
+            wind.xyz += vec3(cbezier(detailphase * VEG_ANIM_DETAIL_FREQ),
+                             cbezier((detailphase * VEG_ANIM_DETAIL_FREQ) + VEG_ANIM_AXIS_PHASE_SHIFT),
+                             cbezier(detailphase * VEG_ANIM_DETAIL_FREQ)) *
+                        vcolor.z * force;
+            
+            // Leaf wiggle
+            wind.xyz += vec3(cbezier(detailphase * VEG_ANIM_LEAF_FREQ),
+                             cbezier((detailphase * VEG_ANIM_LEAF_FREQ) + VEG_ANIM_AXIS_PHASE_SHIFT),
+                             cbezier(detailphase * VEG_ANIM_LEAF_FREQ)) *
+                        vcolor.r * force * VEG_ANIM_LEAF_STRENGTH;
+
+            // Rotate the vector to compensate for the model orientation
+            wind.xyz = inverse(modelworld) * wind.xyz;
+        }
+    ]
+]
+
 // mdltype:
 //    a -> alpha test
 //    b -> dual-quat skeletal animation
+//    v -> vegetation
 
 mdlopt = [ >= (strstr $modeltype $arg1) 0 ]
 
@@ -80,6 +134,14 @@ shadowmodelvertexshader = [
             uniform vec2 texscroll;
             varying vec2 texcoord0;
         ])
+        @(? (mdlopt "v") [
+            attribute vec4 vcolor;
+            uniform float millis;
+            uniform mat3 modelworld;
+            uniform float vegetationphase;
+            uniform bool vegetationanim;
+            @(cbezier)
+        ])
         void main(void)
         {
             @(if (mdlopt "b") [
@@ -88,7 +150,13 @@ shadowmodelvertexshader = [
                 #define mpos vvertex
             ]])
 
-            gl_Position = modelmatrix * mpos;
+            @(? (mdlopt "v") [
+                vec4 wind = vec4(0);
+                @(vegetationwind)
+                gl_Position = modelmatrix * (mpos + wind);
+            ] [
+                gl_Position = modelmatrix * mpos;
+            ])
 
             @(? (mdlopt "a") [
                 texcoord0 = vtexcoord0 + texscroll;
@@ -128,6 +196,7 @@ shadowmodelshader = [
 
 shadowmodelshader "shadowmodel" ""
 shadowmodelshader "alphashadowmodel" "a"
+shadowmodelshader "vegetationshadowmodel" "av"
 
 // mdltype:
 //    a -> alpha test
@@ -141,6 +210,7 @@ shadowmodelshader "alphashadowmodel" "a"
 //    t -> transparent 
 //    x -> game specified mixer
 //    p -> game specified pattern
+//    v -> vegetation
 
 modelvertexshader = [
     local modeltype
@@ -167,6 +237,13 @@ modelvertexshader = [
             uniform float patternscale;
             varying vec2 texcoord1;
         ])
+        @(? (mdlopt "v") [
+            attribute vec4 vcolor;
+            uniform float millis;
+            uniform float vegetationphase;
+            uniform bool vegetationanim;
+            @(cbezier)
+        ])
 
         void main(void)
         {
@@ -178,7 +255,13 @@ modelvertexshader = [
                 @(qtangentdecode (mdlopt "n"))
             ]])
 
-            gl_Position = modelmatrix * mpos;
+            @(? (mdlopt "v") [
+                vec4 wind = vec4(0);
+                @(vegetationwind)
+                gl_Position = modelmatrix * (mpos + wind);
+            ] [
+                gl_Position = modelmatrix * mpos;
+            ])
 
             texcoord0 = vtexcoord0 + texscroll;
 

--- a/src/engine/model.h
+++ b/src/engine/model.h
@@ -4,7 +4,7 @@ struct model
 {
     char *name;
     float spinyaw, spinpitch, spinroll, offsetyaw, offsetpitch, offsetroll;
-    bool shadow, alphashadow, depthoffset;
+    bool shadow, alphashadow, depthoffset, vegetation;
     float scale;
     vec translate;
     BIH *bih;
@@ -13,7 +13,7 @@ struct model
     char *collidemodel;
     int collide, batch;
 
-    model(const char *name) : name(name ? newstring(name) : NULL), spinyaw(0), spinpitch(0), spinroll(0), offsetyaw(0), offsetpitch(0), offsetroll(0), shadow(true), alphashadow(true), depthoffset(false), scale(1.0f), translate(0, 0, 0), bih(0), bbcenter(0, 0, 0), bbradius(-1, -1, -1), bbextend(0, 0, 0), collidecenter(0, 0, 0), collideradius(-1, -1, -1), rejectradius(-1), height(0.9f), collidexyradius(0), collideheight(0), collidemodel(NULL), collide(COLLIDE_OBB), batch(-1) {}
+    model(const char *name) : name(name ? newstring(name) : NULL), spinyaw(0), spinpitch(0), spinroll(0), offsetyaw(0), offsetpitch(0), offsetroll(0), shadow(true), alphashadow(true), depthoffset(false), vegetation(false), scale(1.0f), translate(0, 0, 0), bih(0), bbcenter(0, 0, 0), bbradius(-1, -1, -1), bbextend(0, 0, 0), collidecenter(0, 0, 0), collideradius(-1, -1, -1), rejectradius(-1), height(0.9f), collidexyradius(0), collideheight(0), collidemodel(NULL), collide(COLLIDE_OBB), batch(-1) {}
     virtual ~model() { DELETEA(name); DELETEP(bih); }
     virtual void calcbb(vec &center, vec &radius) = 0;
     virtual void calctransform(matrix4x3 &m) = 0;

--- a/src/engine/rendermodel.cpp
+++ b/src/engine/rendermodel.cpp
@@ -42,6 +42,13 @@ MODELTYPE(MDL_IQM, iqm);
 
 #define checkmdl if(!loadingmodel) { conoutf("\frNot loading a model"); return; }
 
+void mdlvegetation(int *vegetation)
+{
+    checkmdl;
+    loadingmodel->vegetation = *vegetation != 0;
+}
+COMMAND(0, mdlvegetation, "i");
+
 void mdlmaterial(int *material1, int *material2)
 {
     checkmdl;


### PR DESCRIPTION
This change introduces procedural vegetation animation.
With it, it's no longer necessary to manually animate trees, etc.

In order to use this functionality your model needs to have the following information supplied in vertex colors:

* red channel - leaf wiggliness
* green channel - animation phase shift
* blue - detail (branch) sway

In addition, you must enable it via 'mdlvegetation 1' in your model config.

There's a neat piece of software (suggested by Ardelico) TreeIt. It can quickly generate very high quality vegetation and can export to .obj, which then can be loaded up in the game in order to see the new functionality working out-of-the-box (with a provided config).

https://www.youtube.com/watch?v=8CEIbPGJ_ro