### PR TITLE
Improvements to the Settings UI

### DIFF
--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -111,6 +111,34 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                 uibar 1 0
                                 uitablerow [
                                     uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Texture Quality"
+                                        uialign -1 0
+                                    ]
+                                    uiselect 0.2 0.025 "texreduce" [
+                                        12 "^f0Very Low"    []
+                                        6 "^f2Low"          []
+                                        3 "^f6Medium"       []
+                                        0 "^f3High"         []
+                                    ] [uialign 1 0]
+                                ]
+                                uitablerow [
+                                    uihlist $ui_padbutton [
+                                        uifill $ui_checksize
+                                        uitextleft "Reflection Map Quality"
+                                        uialign -1 0
+                                    ]
+                                    uiselect 0.2 0.025 "envmapsize" [
+                                        4 "^f0Low"          []
+                                        6 "^f2Medium"       []
+                                        8 "^f6High"         []
+                                        10 "^f3Very High"   []
+                                    ] [uialign 1 0]
+                                ]
+
+                                uibar 1 0
+                                uitablerow [
+                                    uihlist $ui_padbutton [
                                         uicheckbox "Soft Particles" $softparticles $ui_checksize [softparticles = (! $softparticles)]
                                         uialign -1 0
                                     ]
@@ -151,41 +179,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         2 "^f3High"         []
                                     ] [uialign 1 0]
                                 ]
-                                uitablerow [
-                                    uihlist $ui_padbutton [
-                                        uifill $ui_checksize
-                                        uitextleft "Texture Quality"
-                                        uialign -1 0
-                                    ]
-                                    uihlist $ui_padbutton [
-                                        uihorzslider "texreduce" 0 12 1 0.2 0.025 [
-                                            uivlist 0 [
-                                                uifill 0.050 0
-                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- $texreduce -2) 8) 1 0.5)) $texreduce)
-                                                // HSL allows for changing just hue with respect to slider value, is then converted to RGB and then hex.
-                                                // Number inside deepest parentheses is the offset, number afterward is the rate of hue change; 2 and 8 here respectively.
-                                            ]
-                                        ]
-                                        uialign 1 0
-                                    ]
-                                ]
-                                uitablerow [
-                                    uihlist $ui_padbutton [
-                                        uifill $ui_checksize
-                                        uitextleft "Envmap Quality"
-                                        uialign -1 0
-                                    ]
-                                    uihlist $ui_padbutton [
-                                        uihorzslider "envmapsize" 4 10 1 0.2 0.025 [
-                                            uivlist 0 [
-                                                uifill 0.050 0
-                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- 10 $envmapsize) 10) 1 0.5)) $envmapsize)
-                                            ]
-                                        ]
-                                        uialign 1 0
-                                    ]
-                                ]
-                                
+
                             ] 1 [ // Display Tab
                                 //Render scale slider
                                 uitablerow [

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -96,7 +96,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                             ]
                                             uihlist $ui_padbutton [
                                                 uicheckbox "Caustics" $caustics $ui_checksize [caustics = (! $caustics)]
-                                                uialign -1 0	
+                                                uialign -1 0
                                             ]
                                             uihlist $ui_padbutton [
                                                 uicheckbox "Animation" $vertwater $ui_checksize [vertwater = (! $vertwater)]
@@ -148,7 +148,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                     uiselect 0.2 0.025 "mapeffects" [
                                         0 "^f0Low"          []
                                         1 "^f2Medium"       []
-                                        2 "^f6High"         []
+                                        2 "^f3High"         []
                                     ] [uialign 1 0]
                                 ]
                                 uitablerow [
@@ -325,7 +325,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                             uivlist 0 [
                                                 uifill 0.050 0
                                                 uitext $maxfps
-                                                    
+
                                             ]
                                         ]
                                         uialign 1 0
@@ -370,7 +370,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         ]
                                         uialign 1 0
                                     ]
-                                ]  
+                                ]
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                         uifill $ui_checksize
@@ -387,7 +387,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uialign 1 0
                                     ]
                                 ]
-                                uibar 1 0   
+                                uibar 1 0
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                         uifill $ui_checksize
@@ -536,25 +536,25 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                     uihlist $ui_padbutton [
                                       uicheckbox "Show Minimap" $showminimap $ui_checksize [showminimap = (! $showminimap)]
                                       uialign -1 0
-                                    ] 
+                                    ]
                                 ]
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                       uicheckbox "Show Moves Remaining" $showmovecount $ui_checksize [showmovecount = (! $showmovecount)]
                                       uialign -1 0
-                                    ] 
+                                    ]
                                 ]
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                       uicheckbox "Show Weight" $showweight $ui_checksize [showweight = (! $showweight)]
                                       uialign -1 0
-                                    ] 
+                                    ]
                                 ]
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                       uicheckbox "Show Speed" $showvelocity $ui_checksize [showvelocity = (! $showvelocity)]
                                       uialign -1 0
-                                    ] 
+                                    ]
                                 ]
 
                             ] 6 [ //Autoexec Tab

--- a/config/ui/settings.cfg
+++ b/config/ui/settings.cfg
@@ -192,7 +192,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "gscale" 25 100 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext (format "^f[%1]%2^%" (rgbtohex @(hsltorgb (*f (- 100 $gscale) 1.6) 1 0.5)) $gscale)
+                                                uitext (format "^f[%1]%2%%" (rgbtohex @(hsltorgb (*f (- 100 $gscale) 1.6) 1 0.5)) $gscale)
                                                 // HSL allows for changing just hue with respect to slider value, is then converted to RGB and then hex.
                                                 // Number preceding gscale is the offset, number afterward is the rate of hue change; 100 and 1.6 here respectively.
                                             ]
@@ -343,7 +343,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "mastervol" 0 255 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext $mastervol
+                                                uitext (format "%1%%" (toint (*f (divf $mastervol 255) 100)))
                                             ]
                                         ]
                                         uialign 1 0
@@ -359,7 +359,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "soundvol" 0 255 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext $soundvol
+                                                uitext (format "%1%%" (toint (*f (divf $soundvol 255) 100)))
                                             ]
                                         ]
                                         uialign 1 0
@@ -375,7 +375,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "musicvol" 0 255 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext $musicvol
+                                                uitext (format "%1%%" (toint (*f (divf $musicvol 255) 100)))
                                             ]
                                         ]
                                         uialign 1 0
@@ -407,7 +407,7 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                         uihorzslider "fullbrightmodels" 0 200 1 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext $fullbrightmodels
+                                                uitext (format "%1%%" (toint (+f (divf $fullbrightmodels 2) 100)))
                                             ]
                                         ]
                                         uialign 1 0
@@ -417,14 +417,14 @@ uimenu "settings" "Settings" "textures/icons/settings" [
                                 uitablerow [
                                     uihlist $ui_padbutton [
                                         uifill $ui_checksize
-                                        uitextleft "Race Player Opacity"
+                                        uitextleft "Race Mode Player Opacity"
                                         uialign -1 0
                                     ]
                                     uihlist $ui_padbutton [
                                         uihorzslider "playerghostblend" 0 1 .125 0.2 0.025 [
                                             uivlist 0 [
                                                 uifill 0.050 0
-                                                uitext $playerghostblend
+                                                uitext (format "%1%%" (toint (*f $playerghostblend 100)))
                                             ]
                                         ]
                                         uialign 1 0


### PR DESCRIPTION
List of changes:

- "Texture Quality" has been moved from a slider to a button
- "Envmap Quality" has been renamed to "Reflection Map Quality" to avoid technical terms in the UI
- "Reflection Map Quality" has been moved from a slider to a button
- "Render scale" has been given a unit (%)
- `mastervol`, `soundvol` and `musicvol` have been truncated to remain between 0 and 100 in the UI and has been given a unit (%)
- `fullbrightmodels` has been truncated to remain between 100 and 200 and has been given a unit (%)
- "Race Player Opacity" was renamed to "Race Mode Player Opacity" due to a possibly offensive misread / innuendo. (Player Race? Colour? Race [of the] Player?)
- "Race Mode Player Opacity" has been truncated to remain between 0 and 100 and has been given a unit (%)