### PR TITLE
Keep the event queue awake on all platforms.

### DIFF
--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -835,9 +835,7 @@ void progress(float bar1, const char *text1)
     }
     clientkeepalive();
 
-    #ifdef __APPLE__
-    interceptkey(SDLK_UNKNOWN); // keep the event queue awake to avoid 'beachball' cursor
-    #endif
+    interceptkey(SDLK_UNKNOWN); // keep the event queue awake to avoid appearing unresponsive
 
     setsvar("progresstitle", text1 ? text1 : "Loading..");
     setfvar("progressamt", bar1);


### PR DESCRIPTION
Fixes #814 

Should be backported to stable if merged.