### PR TITLE
Fix display of logo with background.

### DIFF
--- a/config/usage.cfg
+++ b/config/usage.cfg
@@ -426,6 +426,7 @@ setdesc "gauntletrace" "requests a map change to gauntlet race on a given map;^n
 
 //user interface and hud settings
 setdesc "showfps" "display the frames per second counter on the hud;^n0 = no display, 1 = display average fps, 2 = display average fps along with best and worst difference" "value"
+setdesc "showloadinglogos" "display logos while not in game" "boolean"
 setdesc "showvelocity" "display the velocity indicator on the hud" "value"
 setdesc "showconsole" "display the console" "boolean"
 setdesc "showminimap" "toggle minimap visibility" "boolean"

--- a/src/game/hud.cpp
+++ b/src/game/hud.cpp
@@ -1817,6 +1817,8 @@ namespace hud
             drawquad(0, 0, w, h, offsetx, offsety, 1-offsetx, 1-offsety);
         }
 
+        resethudshader();
+
         if(showloadinglogos)
         {
             gle::colorf(1, 1, 1, 1);


### PR DESCRIPTION
Fixes #862

Calls `resethudshader()` before displaying the logo when `showloadinglogos` is enabled.
Added documentation for that variable.
