### PR TITLE
Reimplement editing quit and disconnect warnings in the menu.

### DIFF
--- a/config/ui/main.cfg
+++ b/config/ui/main.cfg
@@ -38,8 +38,8 @@ uimenu "main" "Main Menu" "textures/icon" [
                 uibuttonm "Server Browser" "textures/servers/list" [uiopen "servers"] 0 main_servers
                 uibuttonm "Settings" "textures/icons/settings" [uiopen "settings"] 0 main_settings
                 uibuttonm "Help and Support" $questiontex [uiopen "help"] 0 main_help
-                uibuttonm "Disconnect" "textures/servers/disconnect" [disconnect] (= (isconnected) 0) main_disconnect
-                uibuttonm "Quit" "textures/icons/warning" [quit] 0 main_quit
+                uibuttonm "Disconnect" "textures/servers/disconnect" [uiopen "disconnectwarn"] (= (isconnected) 0) main_disconnect
+                uibuttonm "Quit" "textures/icons/warning" [uiopen "quitwarn"] 0 main_quit
             ]
         ]
     ]

--- a/config/ui/main.cfg
+++ b/config/ui/main.cfg
@@ -32,14 +32,21 @@ uimenu "main" "Main Menu" "textures/icon" [
                 uitext $ui_main_version $ui_textsmall
             ]
             uivlist $ui_padbutton [
+                // Are we connected and editing? Determines if confirmations are shown.
+                local isediting
+                isediting = (&& (= $gamemode $modeidxediting) (isconnected))
                 uialign 0 -1
                 uibuttonm "Profile Setup" "textures/icons/player" [uiopen "profile"] 0 main_profile
                 uibuttonm "Select Map/Mode" "textures/icons/maps" [uiopen "maps"] 0 main_maps
                 uibuttonm "Server Browser" "textures/servers/list" [uiopen "servers"] 0 main_servers
                 uibuttonm "Settings" "textures/icons/settings" [uiopen "settings"] 0 main_settings
                 uibuttonm "Help and Support" $questiontex [uiopen "help"] 0 main_help
-                uibuttonm "Disconnect" "textures/servers/disconnect" [uiopen "disconnectwarn"] (= (isconnected) 0) main_disconnect
-                uibuttonm "Quit" "textures/icons/warning" [uiopen "quitwarn"] 0 main_quit
+                uibuttonm "Disconnect" "textures/servers/disconnect" [
+                    if $isediting [uiopen "disconnectwarn"] disconnect
+                ] (= (isconnected) 0) main_disconnect
+                uibuttonm "Quit" "textures/icons/warning" [
+                    if $isediting [uiopen "quitwarn"] quit
+                ] 0 main_quit
             ]
         ]
     ]

--- a/config/ui/package.cfg
+++ b/config/ui/package.cfg
@@ -45,7 +45,7 @@ uimenu "disconnectwarn" "Disconnect" $alerttex [
             uibutton "No" 0.1 [] [uiclose "disconnectwarn"] [] [] 0 [] [] $colourred
         ]
     ]
-] [if (|| (!= $gamemode 1) (= (isconnected) 0)) [uiclose "disconnectwarn"]]
+] [if (|| (!= $gamemode $modeidxediting) (= (isconnected) 0)) [uiclose "disconnectwarn"; disconnect]]
 
 uimenu "quitwarn" "Quit" $alerttex [
     uivlist $ui_padbutton [
@@ -59,4 +59,4 @@ uimenu "quitwarn" "Quit" $alerttex [
             uibutton "No" 0.1 [] [uiclose "quitwarn"] [] [] 0 [] [] $colourred
         ]
     ]
-] [if (|| (!= $gamemode 1) (= (isconnected) 0)) [uiclose "quitwarn"]]
+] [if (|| (!= $gamemode $modeidxediting) (= (isconnected) 0)) [quit]]

--- a/config/ui/package.cfg
+++ b/config/ui/package.cfg
@@ -45,7 +45,7 @@ uimenu "disconnectwarn" "Disconnect" $alerttex [
             uibutton "No" 0.1 [] [uiclose "disconnectwarn"] [] [] 0 [] [] $colourred
         ]
     ]
-] [if (|| (!= $gamemode $modeidxediting) (= (isconnected) 0)) [uiclose "disconnectwarn"; disconnect]]
+]
 
 uimenu "quitwarn" "Quit" $alerttex [
     uivlist $ui_padbutton [
@@ -59,4 +59,4 @@ uimenu "quitwarn" "Quit" $alerttex [
             uibutton "No" 0.1 [] [uiclose "quitwarn"] [] [] 0 [] [] $colourred
         ]
     ]
-] [if (|| (!= $gamemode $modeidxediting) (= (isconnected) 0)) [quit]]
+]


### PR DESCRIPTION
Closes #871 

Original implementation: e1ea5654d38385f4e580dbe656b91620a3e2eae1

The difference is adding the actual disconnect/quit commands if the ui is displayed outside of edit mode and a minor removal of magic mode number 1 in favor of `modeidxediting`.