### PR TITLE
Fix tesseract.gg link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ The project is Free and Open Source, meaning that you can both use it for free a
 * Quinton "Quin" Reeves - Lead Developer - YouTube channel @ https://youtube.com/qreeves
     - Gameplay and AI Design, Community Management
 
-* Lee "Eihrul" Salzman - Lead Programmer - Check out Tesseract @ https://tesseract.gg/
+* Lee "Eihrul" Salzman - Lead Programmer - Check out Tesseract @ http://tesseract.gg/
     - Engine Designer, Programming Support (there'd be no game without this guy!)
 
 ### Contributors, Developers and Supporters


### PR DESCRIPTION
Fix the http://tesseract.gg link as https isn't supported by the website.

Changes proposed in this request:
- Change https://tesseract.gg to http://tesseract.gg
