### PR TITLE
Check the validity of the sound hook before using it

### DIFF
--- a/src/engine/sound.cpp
+++ b/src/engine/sound.cpp
@@ -597,7 +597,7 @@ int playsound(int n, const vec &pos, physent *d, int flags, int vol, int maxrad,
                 s.chan = chan;
                 if(hook)
                 {
-                    if(issound(*hook) && (!oldhook || *hook != *oldhook)) removesound(*hook);
+                    if(issound(*hook) && (!oldhook || *hook != *oldhook) && n == sounds[*hook].slotnum) removesound(*hook);
                     *hook = s.chan;
                     s.hook = hook;
                 }


### PR DESCRIPTION
One more change to address issues reported in #775
Oftentimes the hooks become invalid, because the channel would be handed over to a different sound.