### PR TITLE
Reset the sound channel before re-use.

### DIFF
--- a/src/engine/sound.cpp
+++ b/src/engine/sound.cpp
@@ -580,6 +580,9 @@ int playsound(int n, const vec &pos, physent *d, int flags, int vol, int maxrad,
 
                 while(chan >= sounds.length()) sounds.add();
 
+                // Reset the sound channel if we haven't had the time to do it beforehand
+                if(sounds[chan].slot) sounds[chan].reset();
+
                 sound &s = sounds[chan];
                 s.slot = slot;
                 s.vol = v;


### PR DESCRIPTION
Frequently, SDL mixer gives us a channel we've used previously,
but haven't had the time to reset its local state.

This is one more change required to address  #775 
