### PR TITLE
Footstep improvements

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1219,16 +1219,19 @@ namespace game
                 if(issound(d->sschan[i])) removesound(d->sschan[i]);
                 d->sschan[i] = -1;
             }
-            if(curfoot != d->lastfoot)
+            if(curfoot >= 0)
             {
-                if(hassound)
+                if(curfoot != d->lastfoot)
                 {
-                    if(d->lastfoot >= 0 && issound(d->sschan[d->lastfoot])) sounds[d->sschan[d->lastfoot]].pos = d->footpos(d->lastfoot);
-                    footstep(d, curfoot);
-                    d->lastfoot = curfoot;
+                    if(hassound)
+                    {
+                        if(d->lastfoot >= 0 && issound(d->sschan[d->lastfoot])) sounds[d->sschan[d->lastfoot]].pos = d->footpos(d->lastfoot);
+                        footstep(d, curfoot);
+                        d->lastfoot = curfoot;
+                    }
                 }
+                else if(hassound) loopi(2) if(issound(d->sschan[i])) sounds[d->sschan[i]].pos = d->footpos(i);
             }
-            else if(hassound) loopi(2) if(issound(d->sschan[i])) sounds[d->sschan[i]].pos = d->footpos(i);
         }
         loopv(d->icons) if(totalmillis-d->icons[i].millis > d->icons[i].fade) d->icons.remove(i--);
     }

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -16,6 +16,8 @@
 #define DNF 1000.0f // for normalized vectors
 #define DVELF 1.0f // for playerspeed based velocity vectors
 
+#define FOOTSTEP_DIST 1.0f // Threshold, below which a footstep will be registered
+
 enum
 {
     S_JUMP = S_GAMESPECIFIC, S_IMPULSE, S_LAND, S_FOOTSTEP, S_SWIMSTEP, S_PAIN, S_DEATH,
@@ -1715,10 +1717,16 @@ struct gameent : dynent, clientstate
 
     int curfoot()
     {
-        vec dir;
-        vecfromyawpitch(yaw, 0, move, strafe && !move ? strafe : 0, dir);
-        dir.mul(radius).add(o).z -= height; // foot furthest away is one being set down
-        return footpos(0).squaredist(dir) > footpos(1).squaredist(dir) ? 0 : 1;
+        int foot = -1;
+        vec fp = feetpos();
+
+        float d0 = fabs(footpos(0).z - fp.z),
+              d1 = fabs(footpos(1).z - fp.z);
+
+        if(d0 < FOOTSTEP_DIST) foot = 0;
+        else if(d1 < FOOTSTEP_DIST) foot = 1;
+
+        return foot;
     }
 
     bool crouching(bool limit = false)


### PR DESCRIPTION
Footsteps are now registered when the distance to ground is below a certain threshold.
That way they're a bit more in sync with the animation.

Also fixes missing footstep sounds when running diagonally.