### PR TITLE
Change included makefile to use pkg-config for all dependencies.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -122,8 +122,8 @@ else
 BIN_SUFFIX=_native
 endif
 endif
-CLIENT_INCLUDES= $(INCLUDES) -I/usr/X11R6/include `$(PKG_CONFIG) --cflags sdl2`
-CLIENT_LIBS= -Lenet -lenet -L/usr/X11R6/lib -lX11 `$(PKG_CONFIG) --libs sdl2` -lSDL2_image -lSDL2_mixer -lz -lGL
+CLIENT_INCLUDES= $(INCLUDES) -I/usr/X11R6/include `$(PKG_CONFIG) --cflags x11 sdl2 SDL2_image SDL2_mixer zlib gl`
+CLIENT_LIBS= -Lenet -lenet -L/usr/X11R6/lib `$(PKG_CONFIG) --libs x11 sdl2 SDL2_image SDL2_mixer zlib gl`
 ifeq (1,$(WANT_STEAM))
 override CLIENT_LIBS+= -L../bin/$(PLATFORM_BIN) -lsteam_api
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ CC_TEMP:=$(CC)
 override CXX=$(TOOLSET_PREFIX)$(CXX_TEMP)
 override CC=$(TOOLSET_PREFIX)$(CC_TEMP)
 
-INCLUDES= -DVERSION_BUILD=$(PLATFORM_BUILD) -DVERSION_BRANCH=\"$(PLATFORM_BRANCH)\" -DVERSION_REVISION=\"$(PLATFORM_REVISION)\" -I. -Ishared -Iengine -Igame -Isupport
+INCLUDES= -DVERSION_BUILD=$(PLATFORM_BUILD) -DVERSION_BRANCH=\"$(PLATFORM_BRANCH)\" -DVERSION_REVISION=\"$(PLATFORM_REVISION)\" -I. -Ishared -Iengine -Igame -Ienet/include -Isupport
 ifeq (1,$(WANT_STEAM))
 override INCLUDES+= -DUSE_STEAM=1 -Isteam
 endif
@@ -122,8 +122,8 @@ else
 BIN_SUFFIX=_native
 endif
 endif
-CLIENT_INCLUDES= $(INCLUDES) `$(PKG_CONFIG) --cflags x11 sdl2 SDL2_image SDL2_mixer gl zlib libenet`
-CLIENT_LIBS= `$(PKG_CONFIG) --libs x11 sdl2 SDL2_image SDL2_mixer gl zlib libenet`
+CLIENT_INCLUDES= $(INCLUDES) `$(PKG_CONFIG) --cflags x11 sdl2 SDL2_image SDL2_mixer zlib gl`
+CLIENT_LIBS= -Lenet -lenet `$(PKG_CONFIG) --libs x11 sdl2 SDL2_image SDL2_mixer zlib gl`
 ifeq (1,$(WANT_STEAM))
 override CLIENT_LIBS+= -L../bin/$(PLATFORM_BIN) -lsteam_api
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -217,8 +217,8 @@ override SERVER_LIBS+= -lsteam_api
 endif
 endif
 else
-SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
-SERVER_LIBS= -Lenet -lenet -lz
+SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) `pkg-config --cflags zlib`
+SERVER_LIBS= -Lenet -lenet `pkg-config --libs zlib`
 ifeq (1,$(WANT_STEAM))
 override SERVER_LIBS+= -L../bin/$(PLATFORM_BIN) -lsteam_api
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ CC_TEMP:=$(CC)
 override CXX=$(TOOLSET_PREFIX)$(CXX_TEMP)
 override CC=$(TOOLSET_PREFIX)$(CC_TEMP)
 
-INCLUDES= -DVERSION_BUILD=$(PLATFORM_BUILD) -DVERSION_BRANCH=\"$(PLATFORM_BRANCH)\" -DVERSION_REVISION=\"$(PLATFORM_REVISION)\" -I. -Ishared -Iengine -Igame -Ienet/include -Isupport
+INCLUDES= -DVERSION_BUILD=$(PLATFORM_BUILD) -DVERSION_BRANCH=\"$(PLATFORM_BRANCH)\" -DVERSION_REVISION=\"$(PLATFORM_REVISION)\" -I. -Ishared -Iengine -Igame -Isupport
 ifeq (1,$(WANT_STEAM))
 override INCLUDES+= -DUSE_STEAM=1 -Isteam
 endif
@@ -122,8 +122,8 @@ else
 BIN_SUFFIX=_native
 endif
 endif
-CLIENT_INCLUDES= $(INCLUDES) -I/usr/X11R6/include `$(PKG_CONFIG) --cflags x11 sdl2 SDL2_image SDL2_mixer zlib gl`
-CLIENT_LIBS= -Lenet -lenet -L/usr/X11R6/lib `$(PKG_CONFIG) --libs x11 sdl2 SDL2_image SDL2_mixer zlib gl`
+CLIENT_INCLUDES= $(INCLUDES) `$(PKG_CONFIG) --cflags x11 sdl2 SDL2_image SDL2_mixer gl zlib libenet`
+CLIENT_LIBS= `$(PKG_CONFIG) --libs x11 sdl2 SDL2_image SDL2_mixer gl zlib libenet`
 ifeq (1,$(WANT_STEAM))
 override CLIENT_LIBS+= -L../bin/$(PLATFORM_BIN) -lsteam_api
 endif


### PR DESCRIPTION
This should allow RE to compile on systems that have different package locations then the Makefile expects. I'm not sure why only SDL2 was in a package config to begin with.