### PR TITLE
revert to dynamic allocation in N_UNDO handling

### DIFF
--- a/src/game/server.cpp
+++ b/src/game/server.cpp
@@ -7569,8 +7569,7 @@ namespace server
                         break;
                     }
                     if(p.remaining() < packlen) { disconnect_client(sender, DISC_MSGERR); return; }
-                    uchar s[MAXTRANS];
-                    ucharbuf q(s, MAXTRANS);
+                    packetbuf q(32 + packlen, ENET_PACKET_FLAG_RELIABLE);
                     putint(q, type);
                     putint(q, ci->clientnum);
                     putint(q, unpacklen);


### PR DESCRIPTION
Fixes #841.

The size of undo packets is unbounded in single player.