### PR TITLE
Add ability to open URLs

### DIFF
--- a/config/ui/game/common.cfg
+++ b/config/ui/game/common.cfg
@@ -629,7 +629,7 @@ ui_gameui_openlink_dims = 0.72
                 p_width       = 0.3
                 p_pad_h_shift = 0
                 p_on_click    = [
-                    open_url $gameui_openlink_href
+                    openurl $gameui_openlink_href
                     gameui_close
                 ]
                 p_id          = #(gameui_get_id prettybutton)
@@ -641,7 +641,7 @@ ui_gameui_openlink_dims = 0.72
                 p_width       = 0.3
                 p_pad_h_shift = 0
                 p_on_click    = [
-                    set_clipboard $gameui_openlink_href
+                    setclipboard $gameui_openlink_href
                     gameui_close
                 ]
                 p_id          = #(gameui_get_id prettybutton)

--- a/src/engine/client.cpp
+++ b/src/engine/client.cpp
@@ -40,13 +40,14 @@ bool connected(bool attempt, bool local)
     return curpeer || (attempt && connpeer) || (local && haslocalclients());
 }
 
-bool isvalidurl(char *href){
+bool isvalidurl(char *href)
+{
     int len = strlen(href);
     if(len < 7) return false;
 
-    if(strncmp("http://", href, 7) == 0) return true;
+    if(!strncmp("http://", href, 7)) return true;
 
-    if(len >= 8 && strncmp("https://", href, 8) == 0) return true;
+    if(len >= 8 && !strncmp("https://", href, 8)) return true;
 
     return false;
 }
@@ -76,12 +77,12 @@ ICOMMAND(0, connectedport, "", (),
     intret(address ? address->port : -1);
 });
 
-ICOMMAND(0, open_url, "s", (char *href),
+ICOMMAND(0, openurl, "s", (char *href),
 {
     if(isvalidurl(href)) SDL_OpenURL(href);
 });
 
-ICOMMAND(0, set_clipboard, "s", (char *data),
+ICOMMAND(0, setclipboard, "s", (char *data),
 {
     SDL_SetClipboardText(data);
 });


### PR DESCRIPTION
Implements #1673 
Tested on Arch Linux w/ KDE

Adds the `/openurl <s>` command, which opens the given URL in the user's default browser.
The command checks if the string begins with `http://` or `https://`, and does nothing if the check fails.

Changes proposed in this request:
- `/openurl <s>`
- `/gameui_open_link <s>`
- `/setclipboard <s>`

The UI and clipboard parts of this pull request are not necessary and can be removed if desired.

It's probably also important to note that no parts of the game's UI actually use these commands yet, they just exist in the console for now :)

<img width="1572" height="1239" alt="Screenshot_20251013_001146" src="https://github.com/user-attachments/assets/6ed9d694-e8e6-4988-9bb1-675fa514e1da" />
