### PR TITLE
fix takescreenshot

### DIFF
--- a/config/legacy.cfg
+++ b/config/legacy.cfg
@@ -35,6 +35,6 @@ takescreenshot = [
         ]
         showhud 0
         showconsole 0
+        halos 0
     ]
 ]; setcomplete takescreenshot 1
-


### PR DESCRIPTION
takescreenshot need to be fixed also to no longer show usernames above players and bots as well as no longer show pickup hints from weapons ect.
halos also need to be off for clear clean takescreenshot function

<img width="1920" height="1080" alt="20251211_024125" src="https://github.com/user-attachments/assets/16b032a2-fdb9-4906-bbfa-b10b3b502473" />
